### PR TITLE
feature/app-lifecycle: AppLifecycle + Release workflow + Projects tab rework + dep cleanup 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +803,7 @@ dependencies = [
  "sled",
  "sysinfo 0.35.2",
  "thiserror 1.0.69",
+ "zip",
 ]
 
 [[package]]
@@ -902,6 +912,17 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
 
 [[package]]
 name = "directories"
@@ -5485,6 +5506,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,90 +29,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "accesskit_atspi_common"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890d241cf51fc784f0ac5ac34dfc847421f8d39da6c7c91a0fcc987db62a8267"
-dependencies = [
- "accesskit",
- "accesskit_consumer",
- "atspi-common",
- "serde",
- "thiserror 1.0.69",
- "zvariant",
-]
-
-[[package]]
-name = "accesskit_consumer"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db81010a6895d8707f9072e6ce98070579b43b717193d2614014abd5cb17dd43"
-dependencies = [
- "accesskit",
- "hashbrown 0.15.4",
-]
-
-[[package]]
-name = "accesskit_macos"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0089e5c0ac0ca281e13ea374773898d9354cc28d15af9f0f7394d44a495b575"
-dependencies = [
- "accesskit",
- "accesskit_consumer",
- "hashbrown 0.15.4",
- "objc2 0.5.2",
- "objc2-app-kit 0.2.2",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
-name = "accesskit_unix"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301e55b39cfc15d9c48943ce5f572204a551646700d0e8efa424585f94fec528"
-dependencies = [
- "accesskit",
- "accesskit_atspi_common",
- "async-channel",
- "async-executor",
- "async-task",
- "atspi",
- "futures-lite",
- "futures-util",
- "serde",
- "zbus",
-]
-
-[[package]]
-name = "accesskit_windows"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d63dd5041e49c363d83f5419a896ecb074d309c414036f616dc0b04faca971"
-dependencies = [
- "accesskit",
- "accesskit_consumer",
- "hashbrown 0.15.4",
- "static_assertions",
- "windows 0.61.3",
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "accesskit_winit"
-version = "0.29.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cfabe59d0eaca7412bfb1f70198dd31e3b0496fee7e15b066f9c36a1a140a0"
-dependencies = [
- "accesskit",
- "accesskit_macos",
- "accesskit_unix",
- "accesskit_windows",
- "raw-window-handle",
- "winit",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,24 +180,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
  "clipboard-win",
- "image 0.25.6",
+ "image",
  "log",
  "objc2 0.6.1",
  "objc2-app-kit 0.3.1",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation 0.3.1",
- "parking_lot 0.12.5",
+ "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
 ]
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -296,202 +206,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
-name = "ash"
-version = "0.38.0+1.3.281"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
-dependencies = [
- "libloading",
-]
-
-[[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-io"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.0.7",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 1.0.7",
- "tracing",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.0.7",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
-name = "async-trait"
-version = "0.1.88"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "atspi"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83247582e7508838caf5f316c00791eee0e15c0bf743e6880585b867e16815c"
-dependencies = [
- "atspi-common",
- "atspi-connection",
- "atspi-proxies",
-]
-
-[[package]]
-name = "atspi-common"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33dfc05e7cdf90988a197803bf24f5788f94f7c94a69efa95683e8ffe76cfdfb"
-dependencies = [
- "enumflags2",
- "serde",
- "static_assertions",
- "zbus",
- "zbus-lockstep",
- "zbus-lockstep-macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "atspi-connection"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4193d51303d8332304056ae0004714256b46b6635a5c556109b319c0d3784938"
-dependencies = [
- "atspi-common",
- "atspi-proxies",
- "futures-lite",
- "zbus",
-]
-
-[[package]]
-name = "atspi-proxies"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2eebcb9e7e76f26d0bcfd6f0295e1cd1e6f33bedbc5698a971db8dc43d7751c"
-dependencies = [
- "atspi-common",
- "serde",
- "zbus",
-]
 
 [[package]]
 name = "autocfg"
@@ -530,12 +248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,31 +260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2 0.5.2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -598,14 +291,8 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteorder-lite"
@@ -723,16 +410,8 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
- "serde",
- "termcolor",
  "unicode-width",
 ]
-
-[[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -791,16 +470,15 @@ dependencies = [
  "gerber-types",
  "gerber_parser",
  "gerber_viewer",
- "image 0.24.9",
+ "image",
  "kiparse",
- "local-ip-address",
  "log",
  "nalgebra",
  "once_cell",
+ "redb",
  "regex",
  "serde",
  "serde_json",
- "sled",
  "sysinfo 0.35.2",
  "thiserror 1.0.69",
  "zip",
@@ -840,7 +518,7 @@ checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "core-graphics-types 0.1.3",
+ "core-graphics-types",
  "foreign-types",
  "libc",
 ]
@@ -857,42 +535,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -921,7 +569,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -990,7 +638,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1067,13 +715,13 @@ dependencies = [
  "glow",
  "glutin",
  "glutin-winit",
- "image 0.25.6",
+ "image",
  "js-sys",
  "log",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
- "parking_lot 0.12.5",
+ "parking_lot",
  "percent-encoding",
  "profiling",
  "raw-window-handle",
@@ -1144,7 +792,6 @@ version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec6687e5bb551702f4ad10ac428bab12acf9d53047ebb1082d4a0ed8c6251a29"
 dependencies = [
- "accesskit_winit",
  "arboard",
  "bytemuck",
  "egui",
@@ -1189,7 +836,7 @@ dependencies = [
  "ahash",
  "egui",
  "enum-map",
- "image 0.25.6",
+ "image",
  "log",
  "mime_guess2",
  "profiling",
@@ -1227,14 +874,8 @@ version = "0.3.0-alpha.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89365b05cb5d87d86b919437cf81059b1deece869e3c65254bfa100c6ce851dd"
 dependencies = [
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
@@ -1245,12 +886,6 @@ dependencies = [
  "bytemuck",
  "serde",
 ]
-
-[[package]]
-name = "endi"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
 name = "enum-map"
@@ -1269,28 +904,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1301,7 +915,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1341,7 +955,7 @@ dependencies = [
  "epaint_default_fonts",
  "log",
  "nohash-hasher",
- "parking_lot 0.12.5",
+ "parking_lot",
  "profiling",
  "serde",
 ]
@@ -1384,48 +998,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
-name = "exr"
-version = "1.73.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83197f59927b46c04a183a619b7c29df34e63e63c7869320862268c0ef687e0"
-dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,12 +1030,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -1486,7 +1052,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -1502,81 +1068,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "futures-task"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
-
-[[package]]
-name = "futures-util"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
-dependencies = [
- "futures-core",
- "futures-macro",
- "futures-task",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1656,16 +1147,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
-]
-
-[[package]]
-name = "gif"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
-dependencies = [
- "color_quant",
- "weezl",
 ]
 
 [[package]]
@@ -1866,57 +1347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "gpu-allocator"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
-dependencies = [
- "log",
- "presser",
- "thiserror 1.0.69",
- "windows 0.58.0",
-]
-
-[[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-descriptor-types",
- "hashbrown 0.15.4",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,9 +1362,6 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
-dependencies = [
- "foldhash 0.1.5",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1942,7 +1369,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1956,12 +1383,6 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexf-parse"
@@ -1981,7 +1402,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2102,24 +1523,6 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "exr",
- "gif",
- "jpeg-decoder",
- "num-traits",
- "png",
- "qoi",
- "tiff",
-]
-
-[[package]]
-name = "image"
 version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
@@ -2139,15 +1542,6 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -2183,7 +1577,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -2223,9 +1617,6 @@ name = "jpeg-decoder"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "js-sys"
@@ -2235,17 +1626,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "khronos-egl"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
-dependencies = [
- "libc",
- "libloading",
- "pkg-config",
 ]
 
 [[package]]
@@ -2285,7 +1665,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -2293,12 +1673,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lebe"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
@@ -2358,18 +1732,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
-name = "local-ip-address"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
-dependencies = [
- "libc",
- "neli",
- "thiserror 2.0.18",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,7 +1767,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -2470,15 +1832,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,21 +1863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "metal"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-graphics-types 0.2.0",
- "foreign-types",
- "log",
- "objc",
- "paste",
 ]
 
 [[package]]
@@ -2576,7 +1914,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
- "spirv",
  "thiserror 2.0.18",
  "unicode-ident",
 ]
@@ -2623,7 +1960,7 @@ checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -2654,44 +1991,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
-]
-
-[[package]]
-name = "neli"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93062a0dce6da2517ea35f301dfc88184ce18d3601ec786a727a87bf535deca9"
-dependencies = [
- "byteorder",
- "libc",
- "log",
- "neli-proc-macros",
-]
-
-[[package]]
-name = "neli-proc-macros"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8034b7fbb6f9455b2a96c19e6edf8dc9fc34c70449938d8ee3b4df363f61fe"
-dependencies = [
- "either",
- "proc-macro2",
- "quote",
- "serde",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -2777,16 +2076,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
+ "syn",
 ]
 
 [[package]]
@@ -3098,25 +2388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "owned_ttf_parser"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,44 +2397,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3230,7 +2470,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "unicase",
 ]
 
@@ -3270,7 +2510,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3278,23 +2518,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkg-config"
@@ -3364,12 +2587,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "presser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3395,7 +2612,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "version_check",
  "yansi",
 ]
@@ -3416,26 +2633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.36.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
-dependencies = [
- "memchr",
- "serde",
+ "syn",
 ]
 
 [[package]]
@@ -3507,12 +2705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "range-alloc"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
-
-[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3525,32 +2717,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
+name = "redb"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
 dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -3709,19 +2881,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sctk-adwaita"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
-dependencies = [
- "ab_glyph",
- "log",
- "memmap2",
- "smithay-client-toolkit",
- "tiny-skia",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3748,7 +2907,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3764,30 +2923,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "simba"
@@ -3819,22 +2958,6 @@ name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
-
-[[package]]
-name = "sled"
-version = "0.34.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
-dependencies = [
- "crc32fast",
- "crossbeam-epoch",
- "crossbeam-utils",
- "fs2",
- "fxhash",
- "libc",
- "log",
- "parking_lot 0.11.2",
-]
 
 [[package]]
 name = "slotmap"
@@ -3897,15 +3020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,12 +3030,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "strict-num"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strum"
@@ -3939,18 +3047,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]
@@ -3972,7 +3069,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -3986,7 +3083,7 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -3998,29 +3095,7 @@ dependencies = [
  "libc",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
-dependencies = [
- "fastrand",
- "getrandom 0.3.3",
- "once_cell",
- "rustix 1.0.7",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
+ "windows",
 ]
 
 [[package]]
@@ -4049,7 +3124,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4060,7 +3135,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4072,31 +3147,6 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
-]
-
-[[package]]
-name = "tiny-skia"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
-dependencies = [
- "arrayref",
- "arrayvec",
- "bytemuck",
- "cfg-if",
- "log",
- "tiny-skia-path",
-]
-
-[[package]]
-name = "tiny-skia-path"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
-dependencies = [
- "arrayref",
- "bytemuck",
- "strict-num",
 ]
 
 [[package]]
@@ -4133,19 +3183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -4153,9 +3191,6 @@ name = "tracing-core"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "ttf-parser"
@@ -4177,17 +3212,6 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
-
-[[package]]
-name = "uds_windows"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
-dependencies = [
- "memoffset",
- "tempfile",
- "winapi",
-]
 
 [[package]]
 name = "unicase"
@@ -4299,7 +3323,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -4334,7 +3358,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4441,7 +3465,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.37.5",
+ "quick-xml",
  "quote",
 ]
 
@@ -4511,18 +3535,12 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
- "js-sys",
  "log",
- "naga",
- "parking_lot 0.12.5",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",
  "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
  "wgpu-core",
  "wgpu-hal",
  "wgpu-types",
@@ -4546,36 +3564,16 @@ dependencies = [
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.12.5",
+ "parking_lot",
  "portable-atomic",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
  "thiserror 2.0.18",
- "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
  "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-core-deps-apple"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-core-deps-emscripten"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
-dependencies = [
- "wgpu-hal",
 ]
 
 [[package]]
@@ -4593,47 +3591,18 @@ version = "27.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
 dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash",
- "bit-set",
  "bitflags 2.11.0",
- "block",
- "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types 0.2.0",
- "glow",
- "glutin_wgl_sys",
- "gpu-alloc",
- "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.1",
- "js-sys",
- "khronos-egl",
- "libc",
  "libloading",
  "log",
- "metal",
  "naga",
- "ndk-sys",
- "objc",
- "once_cell",
- "ordered-float",
- "parking_lot 0.12.5",
  "portable-atomic",
  "portable-atomic-util",
- "profiling",
- "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "smallvec",
  "thiserror 2.0.18",
- "wasm-bindgen",
- "web-sys",
  "wgpu-types",
- "windows 0.58.0",
- "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4693,22 +3662,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -4720,20 +3679,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -4742,11 +3688,11 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-implement",
+ "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4755,20 +3701,9 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -4779,18 +3714,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4801,7 +3725,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -4822,17 +3746,8 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4842,16 +3757,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5201,7 +4106,6 @@ dependencies = [
  "raw-window-handle",
  "redox_syscall 0.4.1",
  "rustix 0.38.44",
- "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
  "tracing",
@@ -5333,105 +4237,8 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zbus"
-version = "5.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f45e98bc7e6f0988276012797855613cd8269e23b5be62cc4e5d28b7e515d"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-lite",
- "hex",
- "nix",
- "ordered-stream",
- "serde",
- "serde_repr",
- "tracing",
- "uds_windows",
- "windows-sys 0.59.0",
- "winnow",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus-lockstep"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e96e38ded30eeab90b6ba88cb888d70aef4e7489b6cd212c5e5b5ec38045b6"
-dependencies = [
- "zbus_xml",
- "zvariant",
-]
-
-[[package]]
-name = "zbus-lockstep-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6821851fa840b708b4cbbaf6241868cabc85a2dc22f426361b0292bfc0b836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "zbus-lockstep",
- "zbus_xml",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "5.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c8e4e14dcdd9d97a98b189cd1220f30e8394ad271e8c987da84f73693862c2"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
-dependencies = [
- "serde",
- "static_assertions",
- "winnow",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_xml"
-version = "5.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589e9a02bfafb9754bb2340a9e3b38f389772684c63d9637e76b1870377bec29"
-dependencies = [
- "quick-xml 0.36.2",
- "serde",
- "static_assertions",
- "zbus_names",
- "zvariant",
 ]
 
 [[package]]
@@ -5451,7 +4258,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -5471,7 +4278,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
  "synstructure",
 ]
 
@@ -5505,7 +4312,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn",
 ]
 
 [[package]]
@@ -5535,54 +4342,4 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
-]
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
-name = "zvariant"
-version = "5.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "winnow",
- "zvariant_derive",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "static_assertions",
- "syn 2.0.104",
- "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,25 @@ authors = ["James Bonanno <atlantix-eda@proton.me>"]
 
 [workspace.dependencies]
 egui = "0.33"
-eframe = "0.33"
+# eframe features: disable `accesskit` (~10 direct + ~30 transitive crates:
+# accesskit_*, atspi, zbus, zvariant — screen-reader plumbing CopperForge
+# doesn't target). Keep glow (default OpenGL backend), default_fonts, the
+# Linux display servers (wayland + x11), and winit defaults.
+eframe = { version = "0.33", default-features = false, features = [
+    "default_fonts",
+    "glow",
+    "wayland",
+    "x11",
+] }
 egui-file-dialog = "0.12.0"
 
 # Image and graphics handling
 egui_extras = { version = "0.33", features = ["image"] } # For image loading and other utilities
-image = "0.24" # For image loading
+# Only PNG decoding/encoding is needed — quadrant export writes PNG, About
+# panel loads a PNG logo. Narrowing default-features off cuts JPEG/GIF/TIFF/
+# BMP/ICO/WebP decoders (~25 transitive crates). Bumped to 0.25 to match
+# the version egui_extras-0.33 resolves to internally so cargo unifies.
+image = { version = "0.25", default-features = false, features = ["png"] }
 
 # Gerber and PCB handling
 gerber_viewer = "0.5.0"
@@ -63,15 +76,14 @@ serde_json = "1.0"
 sysinfo = "0.35.1"
 chrono = { version = "0.4.41", features = ["serde"] }
 chrono-tz = "0.10"
-local-ip-address = "0.6.5"
 egui_dock = {version = "0.18.0", features=["serde"]}
 
 regex = "1.10"
 once_cell = "1.19"
 
 
-# Project database
-sled = "0.34"
+# Project database (embedded pure-Rust KV store)
+redb = "2.2"
 bincode = "1.3"
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,6 @@ thiserror = "1.0"
 
 # Tree view
 egui_ltreeview = "0.6.0"
+
+# Release archives (gerber+drill zip)
+zip = { version = "2.2", default-features = false, features = ["deflate"] }

--- a/crates/copperforge-core/Cargo.toml
+++ b/crates/copperforge-core/Cargo.toml
@@ -37,7 +37,6 @@ serde_json = { workspace = true }
 sysinfo = { workspace = true }
 chrono = { workspace = true }
 chrono-tz = { workspace = true }
-local-ip-address = { workspace = true }
 egui_dock = { workspace = true }
 
 regex = { workspace = true }
@@ -45,8 +44,8 @@ once_cell = { workspace = true }
 
 
 
-# Project database
-sled = { workspace = true }
+# Project database (embedded pure-Rust KV store)
+redb = { workspace = true }
 bincode = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/copperforge-core/Cargo.toml
+++ b/crates/copperforge-core/Cargo.toml
@@ -52,3 +52,6 @@ thiserror = { workspace = true }
 
 # Tree view
 egui_ltreeview = { workspace = true }
+
+# Release archives (gerber+drill zip)
+zip = { workspace = true }

--- a/crates/copperforge-core/src/app.rs
+++ b/crates/copperforge-core/src/app.rs
@@ -187,7 +187,11 @@ impl CopperForgeApp {
         let (kicad_version, kicad_cli_method) = Self::probe_kicad_cli();
 
         // ── Stage 3: InitializeDb ────────────────────────────────
-        let db_path = config_path.join("projects.db");
+        // Filename changed from "projects.db" (sled dir) to "projects.redb"
+        // (single redb file) as part of the sled→redb swap. Old sled data
+        // at ~/.config/copperforge/projects.db/ is left in place and
+        // harmless; manual deletion reclaims disk space.
+        let db_path = config_path.join("projects.redb");
         let project_db = match crate::project_manager::database::ProjectDatabase::new(&db_path) {
             Ok(db) => db,
             Err(e) => panic_init(
@@ -197,7 +201,7 @@ impl CopperForgeApp {
                     &format!("Failed to open sled DB at {}", db_path.display()),
                     "Another CopperForge process may be holding a lock — close it.",
                     "Or the database is corrupted — delete the directory and restart:",
-                    "  rm -rf ~/.config/copperforge/projects.db",
+                    "  rm ~/.config/copperforge/projects.redb",
                 ],
             ),
         };

--- a/crates/copperforge-core/src/app.rs
+++ b/crates/copperforge-core/src/app.rs
@@ -9,226 +9,195 @@ use crate::display::DisplayManager;
 use crate::drc_operations::DrcManager;
 
 use crate::event_logger::{ReactiveEventLogger, ReactiveEventLoggerState, LogColors};
-use egui_mobius_reactive::*; 
+use egui_mobius_reactive::*;
 use gerber_viewer::{
-   BoundingBox, GerberLayer, 
+   BoundingBox,
    ViewState, UiState, GerberTransform
 };
-// Import platform modules
 use crate::platform::parameters::gui::VERSION;
-// Import new modules
 use crate::project;
 use crate::ui;
 use crate::project_manager;
+use crate::services::SharedServices;
 
 use crate::ui::{Tab, TabKind, TabViewer, initialize_and_show_banner, show_system_info};
 
-use crate::project::{load_demo_gerber, ProjectManager, ProjectState, manager::ProjectConfig};
+use crate::project::{load_demo_gerber, ProjectState, manager::ProjectConfig};
 use crate::display::GridSettings;
 
-/// The main application struct
+/// The main application struct. A thin outer layer around `SharedServices`;
+/// panels operate on services, never directly on fields of this struct.
 pub struct CopperForgeApp {
+    /// All cross-panel state lives here.
+    pub services: SharedServices,
+
     // ── Citizen infrastructure ────────────────────────────────
     pub dispatcher: egui_citizen::Dispatcher,
     pub app_messages: Vec<crate::messages::AppMessage>,
 
-    // Legacy single layer support (for compatibility)
-    pub gerber_layer: GerberLayer,
-    pub view_state: ViewState,
-    pub ui_state: UiState,
-    pub needs_initial_view: bool,
-
-    pub rotation_degrees: f32,
-    
-    // Logger state and colors
-    pub logger_state : Dynamic<ReactiveEventLoggerState>,
-    pub log_colors   : Dynamic<LogColors>,
-    
-    // Display settings
-    pub display_manager: DisplayManager,
-    
-    // DRC management
-    pub drc_manager: DrcManager,
-    
-    // Global units setting
-    pub global_units_mils: bool, // true = mils, false = mm
-    
-    // Grid Settings
-    pub grid_settings: GridSettings,
-    
-    // Project management
-    pub project_manager: ProjectManager,
-    
-    // Layer management (replaces ECS)
-    pub layer_store: crate::layer_store::LayerStore,
-
-    // Dock state
+    // ── Dock state (eframe owns) ──────────────────────────────
     dock_state: DockState<Tab>,
-    pub config_path: PathBuf,
-    
-    
-    // Zoom window state
-    pub zoom_window_start: Option<Pos2>,
-    pub zoom_window_dragging: bool,
-    
-    // User preferences
-    pub user_timezone: Option<String>,
-    pub use_24_hour_clock: bool, // true = 24-hour, false = 12-hour
-    
-    // Modal states
-    pub show_about_modal: bool,
-    pub show_kicad_version_modal: bool,
-    pub kicad_version: Option<String>,
-    /// Cached discovery method for `kicad-cli` — one of "path", "flatpak", "snap".
-    /// Populated once at first use; lets us build a Command without re-probing
-    /// (probing costs ~1-3s for Flatpak sandbox cold-start).
-    pub kicad_cli_method: Option<String>,
-    
-    // Origin setting mode
-    pub setting_origin_mode: bool,
-    
-    // Track if origin has been set by user
-    pub origin_has_been_set: bool,
-    
-    // Enterprise feature: Ruler tool
-    pub ruler_active: bool,
-    pub ruler_start: Option<nalgebra::Point2<f64>>,
-    pub ruler_end: Option<nalgebra::Point2<f64>>,
-    pub ruler_dragging: bool,
-    pub ruler_drag_start: Option<nalgebra::Point2<f64>>,
-    
-    // Latched measurement (persists after measurement mode is exited)
-    pub latched_measurement_start: Option<nalgebra::Point2<f64>>,
-    pub latched_measurement_end: Option<nalgebra::Point2<f64>>,
-    
-    
-    // BOM panel state
-    pub bom_state: Option<ui::BomPanelState>,
-    
-    // Project manager state
-    pub project_manager_state: Option<project_manager::ProjectManagerState>,
 
-    // File dialogs
+    // ── File dialogs (I/O handles) ────────────────────────────
+    pub pcb_file_dialog: egui_file_dialog::FileDialog,
+    pub last_picked_pcb_file: Option<PathBuf>,
     pub projects_directory_dialog: egui_file_dialog::FileDialog,
-
-    // Track last picked directory to avoid re-processing
     pub last_picked_projects_directory: Option<PathBuf>,
 
-    // Terminal panel buffers (OS shell)
+    // ── Panel-owned state (temporary — migrates into citizens) ─
+    pub bom_state: Option<ui::BomPanelState>,
+    pub project_manager_state: Option<project_manager::ProjectManagerState>,
     pub term_output: Vec<String>,
     pub term_cmd_buf: String,
-
-    // Shell panel buffers (CopperForge command shell)
     pub shell_log: Vec<String>,
     pub shell_cmd_buf: String,
 }
 
 impl Drop for CopperForgeApp {
     fn drop(&mut self) {
-        // Save dock state when application closes
         self.save_dock_state();
-        // Save project config with time settings
         self.save_settings();
     }
 }
 
+/// Panic with a lengthy, stage-aware diagnostic when init fails.
+fn panic_init(stage: &str, err: impl std::fmt::Display, hints: &[&str]) -> ! {
+    eprintln!();
+    eprintln!("============================================================");
+    eprintln!("  CopperForge — initialization failure");
+    eprintln!("============================================================");
+    eprintln!();
+    eprintln!("  Stage: {stage}");
+    eprintln!("  Error: {err}");
+    eprintln!();
+    if !hints.is_empty() {
+        eprintln!("  Hints:");
+        for h in hints {
+            eprintln!("    • {h}");
+        }
+        eprintln!();
+    }
+    eprintln!("  If this persists, capture the above and file an issue:");
+    eprintln!("    https://github.com/Atlantix-EDA/CopperForge/issues");
+    eprintln!("============================================================");
+    eprintln!();
+    panic!("CopperForge init failed at stage: {stage}");
+}
+
 impl CopperForgeApp {
-    /// Sync units between legacy global_units_mils and layer_store
     pub fn sync_units_to_ecs(&mut self) {
-        if self.global_units_mils {
-            self.layer_store.units.display_unit = crate::layer_store::DisplayUnit::Mils;
+        if self.services.global_units_mils {
+            self.services.layer_store.units.display_unit = crate::layer_store::DisplayUnit::Mils;
         } else {
-            self.layer_store.units.display_unit = crate::layer_store::DisplayUnit::Millimeters;
+            self.services.layer_store.units.display_unit = crate::layer_store::DisplayUnit::Millimeters;
         }
     }
 
-    /// Sync units from layer_store to legacy global_units_mils
     pub fn sync_units_from_ecs(&mut self) {
-        self.global_units_mils = self.layer_store.units.is_mils();
+        self.services.global_units_mils = self.services.layer_store.units.is_mils();
     }
 
-    /// Sync zoom from legacy view_state to layer_store
     pub fn sync_zoom_to_ecs(&mut self) {
-        self.layer_store.zoom.set_scale(self.view_state.scale);
-        self.layer_store.zoom.center_x = self.view_state.translation.x;
-        self.layer_store.zoom.center_y = self.view_state.translation.y;
+        self.services.layer_store.zoom.set_scale(self.services.view_state.scale);
+        self.services.layer_store.zoom.center_x = self.services.view_state.translation.x;
+        self.services.layer_store.zoom.center_y = self.services.view_state.translation.y;
     }
 
-    /// Sync zoom from layer_store to legacy view_state
     pub fn sync_zoom_from_ecs(&mut self) {
-        self.view_state.scale = self.layer_store.zoom.scale;
-        self.view_state.translation.x = self.layer_store.zoom.center_x;
-        self.view_state.translation.y = self.layer_store.zoom.center_y;
+        self.services.view_state.scale = self.services.layer_store.zoom.scale;
+        self.services.view_state.translation.x = self.services.layer_store.zoom.center_x;
+        self.services.view_state.translation.y = self.services.layer_store.zoom.center_y;
     }
 
-    /// Render layers using layer_store
     pub fn render_layers_ecs(&mut self, painter: &egui::Painter) {
-        let view_state = self.view_state;
-        let rotation = self.rotation_degrees;
-        self.layer_store.render(painter, view_state, &self.display_manager, rotation);
+        let view_state = self.services.view_state;
+        let rotation = self.services.rotation_degrees;
+        self.services.layer_store.render(painter, view_state, &self.services.display_manager, rotation);
     }
 
     pub fn new() -> Self {
-
-        let gerber_layer = load_demo_gerber();
-        let display_manager = DisplayManager::new();
-        
-        // Force initial view setup to center gerber at origin
         let dummy_viewport = Rect::from_min_size(Pos2::ZERO, Vec2::new(1280.0, 768.0));
-        
+
+        // ── Stage 1: LoadConfig ──────────────────────────────────
+        let config_path: PathBuf = dirs::config_dir()
+            .map(|d| d.join("copperforge"))
+            .unwrap_or_else(|| {
+                panic_init(
+                    "LoadConfig",
+                    "dirs::config_dir() returned None",
+                    &["The OS didn't expose a config directory (XDG_CONFIG_HOME / %APPDATA%).",
+                      "Set XDG_CONFIG_HOME to a writable path and retry."],
+                )
+            });
+        let config = match ProjectConfig::load_from_file(&config_path) {
+            Ok(cfg) => cfg,
+            Err(e) => panic_init(
+                "LoadConfig",
+                e,
+                &[
+                    "project_config.json exists but failed to deserialize.",
+                    "If the file is from an older CopperForge with incompatible schema,",
+                    "delete it: rm ~/.config/copperforge/project_config.json",
+                    "(CopperForge will recreate it with defaults on next launch.)",
+                ],
+            ),
+        };
+
+        // ── Stage 2: DiscoverKiCad (slow on first Flatpak launch) ─
+        let (kicad_version, kicad_cli_method) = Self::probe_kicad_cli();
+
+        // ── Stage 3: InitializeDb ────────────────────────────────
+        let db_path = config_path.join("projects.db");
+        let project_db = match crate::project_manager::database::ProjectDatabase::new(&db_path) {
+            Ok(db) => db,
+            Err(e) => panic_init(
+                "InitializeDb",
+                e,
+                &[
+                    &format!("Failed to open sled DB at {}", db_path.display()),
+                    "Another CopperForge process may be holding a lock — close it.",
+                    "Or the database is corrupted — delete the directory and restart:",
+                    "  rm -rf ~/.config/copperforge/projects.db",
+                ],
+            ),
+        };
+
+        // ── Stage 4: Wire SharedServices ─────────────────────────
         let mut initial_logger_state = ReactiveEventLoggerState::new();
-        // Set timestamp to be unchecked by default
         initial_logger_state.show_timestamps = false;
         let logger_state = Dynamic::new(initial_logger_state);
         let log_colors = Dynamic::new(LogColors::default());
-        let dock_state = Self::create_default_dock_state();
-        
-        // Setup layer store (replaces ECS world)
-        let layer_store = crate::layer_store::LayerStore::default();
+        let project_state = Dynamic::new(config.state.clone());
 
-        // Register all citizen panels with the dispatcher
-        let mut dispatcher = egui_citizen::Dispatcher::new();
-        use egui_citizen::message::CitizenId;
-        for id in [
-            "gerber_view", "view_settings", "drc", "project", "projects",
-            "settings", "bom",
-            "shell", "terminal", "logger",
-        ] {
-            dispatcher.register(CitizenId::new(id));
+        let mut layer_store = crate::layer_store::LayerStore::default();
+        if config.global_units_mils {
+            layer_store.units.display_unit = crate::layer_store::DisplayUnit::Mils;
+        } else {
+            layer_store.units.display_unit = crate::layer_store::DisplayUnit::Millimeters;
         }
-        // Activate gerber_view by default
-        dispatcher.activate(&CitizenId::new("gerber_view"));
-        // Drain initialization messages
-        let _ = dispatcher.drain_messages();
 
-        let mut app = Self {
-            dispatcher,
-            app_messages: Vec::new(),
-            gerber_layer,
+        let services = SharedServices {
+            project_state,
+            logger_state,
+            log_colors,
+            config_path: config_path.clone(),
+            kicad_version,
+            kicad_cli_method,
+            project_db,
+            layer_store,
+            gerber_layer: load_demo_gerber(),
             view_state: ViewState::default(),
             ui_state: UiState::default(),
             needs_initial_view: true,
             rotation_degrees: 0.0,
-            logger_state,
-            log_colors,
-            display_manager,
+            display_manager: DisplayManager::new(),
             drc_manager: DrcManager::new(),
-            global_units_mils: false, // Default to mm
             grid_settings: GridSettings::default(),
-            project_manager: ProjectManager::new(),
-            layer_store,
-            dock_state,
-            config_path: dirs::config_dir()
-                .map(|d| d.join("copperforge"))
-                .unwrap_or_default(),
+            global_units_mils: config.global_units_mils,
+            user_timezone: config.user_timezone.clone(),
+            use_24_hour_clock: config.use_24_hour_clock,
             zoom_window_start: None,
             zoom_window_dragging: false,
-            user_timezone: None,
-            use_24_hour_clock: false, // Default to 12-hour format
-            show_about_modal: false,
-            show_kicad_version_modal: false,
-            kicad_version: None,
-            kicad_cli_method: None,
             setting_origin_mode: false,
             origin_has_been_set: false,
             ruler_active: false,
@@ -238,116 +207,117 @@ impl CopperForgeApp {
             ruler_drag_start: None,
             latched_measurement_start: None,
             latched_measurement_end: None,
-            bom_state: None,
-            project_manager_state: None,
+            show_about_modal: false,
+            show_kicad_version_modal: false,
+            config,
+        };
+
+        // ── Stage 5: Register citizens ───────────────────────────
+        let mut dispatcher = egui_citizen::Dispatcher::new();
+        use egui_citizen::message::CitizenId;
+        for id in [
+            "gerber_view", "view_settings", "drc", "project", "projects",
+            "settings", "bom",
+            "shell", "terminal", "logger",
+        ] {
+            dispatcher.register(CitizenId::new(id));
+        }
+        dispatcher.activate(&CitizenId::new("gerber_view"));
+        let _ = dispatcher.drain_messages();
+
+        let dock_state = Self::create_default_dock_state();
+
+        let mut app = Self {
+            services,
+            dispatcher,
+            app_messages: Vec::new(),
+            dock_state,
+            pcb_file_dialog: egui_file_dialog::FileDialog::new(),
+            last_picked_pcb_file: None,
             projects_directory_dialog: egui_file_dialog::FileDialog::new(),
             last_picked_projects_directory: None,
+            bom_state: None,
+            project_manager_state: None,
             term_output: Vec::new(),
             term_cmd_buf: String::new(),
             shell_log: Vec::new(),
             shell_cmd_buf: String::new(),
         };
-        
-        if let Ok(project_config) = ProjectConfig::load_from_file(&app.config_path) {
-            // Load time settings from saved config
-            app.user_timezone = project_config.user_timezone.clone();
-            app.use_24_hour_clock = project_config.use_24_hour_clock;
-            app.global_units_mils = project_config.global_units_mils;
-            
-            // Sync units with layer store
-            if app.global_units_mils {
-                app.layer_store.units.display_unit = crate::layer_store::DisplayUnit::Mils;
-            } else {
-                app.layer_store.units.display_unit = crate::layer_store::DisplayUnit::Millimeters;
-            }
-            
-            app.project_manager = ProjectManager::from_config(project_config);
-        }
-        
-        let logger = ReactiveEventLogger::with_colors(&app.logger_state, &app.log_colors);
+
+        let logger = ReactiveEventLogger::with_colors(&app.services.logger_state, &app.services.log_colors);
         initialize_and_show_banner(&logger);
-        app.initialize_project();
-        
-        // Force reset view to center the gerber at origin
+        app.prune_stale_project_state();
+
         app.reset_view(dummy_viewport);
-        
+
         app
     }
-    
-    fn initialize_project(&mut self) {
-        let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
-        
-        match &self.project_manager.state.clone() {
+
+    /// Prune project_state if its on-disk artifacts no longer exist.
+    fn prune_stale_project_state(&mut self) {
+        let current = self.services.project_state.get();
+        let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
+        match &current {
             ProjectState::NoProject => {
                 logger.log_info("No previous project found. Please select a PCB file.");
-            },
-            _ => {
-                // Use the centralized project state management
-                self.project_manager.manage_project_state();
+            }
+            ProjectState::PcbSelected { pcb_path }
+            | ProjectState::GeneratingGerbers { pcb_path } => {
+                if !pcb_path.exists() {
+                    self.services.project_state.set(ProjectState::NoProject);
+                }
+            }
+            ProjectState::GerbersGenerated { pcb_path, gerber_dir }
+            | ProjectState::Ready { pcb_path, gerber_dir, .. }
+            | ProjectState::LoadingGerbers { pcb_path, gerber_dir } => {
+                if !pcb_path.exists() || !gerber_dir.exists() {
+                    self.services.project_state.set(ProjectState::NoProject);
+                }
             }
         }
     }
 
     pub fn reset_view(&mut self, viewport: Rect) {
-        // Find bounding box from all loaded layers
-        let combined_bbox = self.layer_store.combined_bounding_box();
-        
-        // Fall back to demo gerber if no layers loaded
-        let bbox = combined_bbox.unwrap_or_else(|| self.gerber_layer.bounding_box().clone());
+        let combined_bbox = self.services.layer_store.combined_bounding_box();
+        let bbox = combined_bbox.unwrap_or_else(|| self.services.gerber_layer.bounding_box().clone());
         let content_width = bbox.width();
         let content_height = bbox.height();
-        
-        // Calculate scale to fit the content (100% zoom)
+
         let scale = f32::min(
             viewport.width() / (content_width as f32),
             viewport.height() / (content_height as f32),
         );
-        // adjust slightly to add a margin
         let scale = scale * 0.95;
 
-        // Handle custom origin case differently
-        if self.display_manager.design_offset.x != 0.0 || self.display_manager.design_offset.y != 0.0 {
-            // When we have a custom origin, position (0,0) at the lower-left area of the viewport
-            // This ensures the PCB is always visible
-            
-            // Position (0,0) at 20% from left and 20% from bottom of viewport
+        if self.services.display_manager.design_offset.x != 0.0 || self.services.display_manager.design_offset.y != 0.0 {
             let origin_screen_x = viewport.left() + viewport.width() * 0.2;
-            let origin_screen_y = viewport.bottom() - viewport.height() * 0.2; // Remember Y is flipped
-            
-            // The origin in gerber coordinates is at design_offset
-            // We need to translate the view so that this point appears at our desired screen position
-            let origin_gerber_x = self.display_manager.design_offset.x;
-            let origin_gerber_y = self.display_manager.design_offset.y;
-            
-            // Calculate the translation needed
-            // Screen position = translation + (gerber_position * scale)
-            // Therefore: translation = screen_position - (gerber_position * scale)
-            self.view_state.translation = Vec2::new(
+            let origin_screen_y = viewport.bottom() - viewport.height() * 0.2;
+
+            let origin_gerber_x = self.services.display_manager.design_offset.x;
+            let origin_gerber_y = self.services.display_manager.design_offset.y;
+
+            self.services.view_state.translation = Vec2::new(
                 origin_screen_x - (origin_gerber_x as f32 * scale),
-                origin_screen_y + (origin_gerber_y as f32 * scale), // + because Y is flipped in screen coords
+                origin_screen_y + (origin_gerber_y as f32 * scale),
             );
         } else {
-            // Standard case: no custom origin
             let gerber_center = bbox.center();
-            
-            // Set center offset to negate the gerber center, forcing it to (0,0)
-            self.display_manager.center_offset = display::VectorOffset {
+
+            self.services.display_manager.center_offset = display::VectorOffset {
                 x: -gerber_center.x,
                 y: -gerber_center.y,
             };
 
-            // Create the transform that will be used during rendering
-            let origin: nalgebra::Vector2<f64> = self.display_manager.center_offset.clone().into();
-            let offset: nalgebra::Vector2<f64> = self.display_manager.design_offset.clone().into();
+            let origin: nalgebra::Vector2<f64> = self.services.display_manager.center_offset.clone().into();
+            let offset: nalgebra::Vector2<f64> = self.services.display_manager.design_offset.clone().into();
             let transform = GerberTransform {
-                rotation: self.rotation_degrees.to_radians(),
-                mirroring: self.display_manager.mirroring.clone().into(),
+                rotation: self.services.rotation_degrees.to_radians(),
+                mirroring: self.services.display_manager.mirroring.clone().into(),
                 origin: origin - offset,
                 offset,
                 scale: 1.0,
             };
 
-            // Compute transformed bounding box
             let outline_vertices: Vec<_> = bbox
                 .vertices()
                 .into_iter()
@@ -357,75 +327,80 @@ impl CopperForgeApp {
             let transformed_bbox = BoundingBox::from_points(&outline_vertices);
             let transformed_center = transformed_bbox.center();
 
-            // Center the view
-            self.view_state.translation = Vec2::new(
+            self.services.view_state.translation = Vec2::new(
                 viewport.center().x - (transformed_center.x as f32 * scale),
                 viewport.center().y + (transformed_center.y as f32 * scale),
             );
         }
 
-        self.view_state.scale = scale;
-        
-        // Update zoom state and set fit-to-view reference
-        self.layer_store.zoom.set_scale(scale);
-        self.layer_store.zoom.set_fit_to_view_scale(scale); // This scale becomes the 100% reference
-        self.layer_store.zoom.center_x = self.view_state.translation.x;
-        self.layer_store.zoom.center_y = self.view_state.translation.y;
-        
-        self.needs_initial_view = false;
+        self.services.view_state.scale = scale;
+
+        self.services.layer_store.zoom.set_scale(scale);
+        self.services.layer_store.zoom.set_fit_to_view_scale(scale);
+        self.services.layer_store.zoom.center_x = self.services.view_state.translation.x;
+        self.services.layer_store.zoom.center_y = self.services.view_state.translation.y;
+
+        self.services.needs_initial_view = false;
     }
-    
+
     /// Zoom to a specific BOM component location
     pub fn zoom_to_component(&mut self, component: &project_manager::bom::BomComponent, viewport: Rect) {
-        // Only allow cross-probing if origin has been set
-        if !self.origin_has_been_set {
-            let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
+        if !self.services.origin_has_been_set {
+            let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
             logger.log_warning("Please set the origin before using cross-probing");
             return;
         }
-        
-        // Component coordinates from KiCad (in mm)
+
         let comp_x = component.x_location;
         let comp_y = component.y_location;
-        
-        // Just center the component at the current zoom level
+
         let viewport_center = viewport.center();
-        self.view_state.translation = Vec2::new(
-            viewport_center.x - (comp_x as f32 * self.view_state.scale),
-            viewport_center.y + (comp_y as f32 * self.view_state.scale),
+        self.services.view_state.translation = Vec2::new(
+            viewport_center.x - (comp_x as f32 * self.services.view_state.scale),
+            viewport_center.y + (comp_y as f32 * self.services.view_state.scale),
         );
-        
-        // Sync zoom state
-        self.layer_store.zoom.center_x = self.view_state.translation.x;
-        self.layer_store.zoom.center_y = self.view_state.translation.y;
-        
-        // Log the action
-        let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
-        logger.log_info(&format!("Cross-probed to component: {} at ({:.2}, {:.2})", 
+
+        self.services.layer_store.zoom.center_x = self.services.view_state.translation.x;
+        self.services.layer_store.zoom.center_y = self.services.view_state.translation.y;
+
+        let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
+        logger.log_info(&format!("Cross-probed to component: {} at ({:.2}, {:.2})",
                                 component.reference, comp_x, comp_y));
     }
-    
-    
-    /// Show clock display in the upper right corner
+
+    /// Open the PCB file dialog.
+    pub fn open_pcb_file_dialog(&mut self) {
+        self.pcb_file_dialog.pick_file();
+    }
+
+    /// Poll the PCB file dialog. On new pick of a .kicad_pcb, updates
+    /// `project_state` to `PcbSelected` and returns the path.
+    pub fn update_pcb_file_dialog(&mut self, ctx: &egui::Context) -> Option<PathBuf> {
+        if let Some(path) = self.pcb_file_dialog.update(ctx).picked() {
+            let path_buf = path.to_path_buf();
+            if self.last_picked_pcb_file.as_ref() != Some(&path_buf) {
+                self.last_picked_pcb_file = Some(path_buf.clone());
+                if path.extension().and_then(|s| s.to_str()) == Some("kicad_pcb") {
+                    self.services.project_state.set(ProjectState::PcbSelected { pcb_path: path_buf.clone() });
+                    return Some(path_buf);
+                }
+            }
+        }
+        None
+    }
+
     fn show_clock_display(&mut self, ui: &mut egui::Ui) {
         use chrono::{Local, Utc};
         use chrono_tz::Tz;
-        
-        // Show version as clickable button
+
         if ui.button(egui::RichText::new(format!("CopperForge v{}", VERSION))
             .color(egui::Color32::from_rgb(180, 200, 255))).clicked() {
-            self.show_about_modal = true;
+            self.services.show_about_modal = true;
         }
 
         ui.separator();
 
-        // Show KiCad version button
-        // Detect KiCad version on first call
-        if self.kicad_version.is_none() {
-            self.detect_and_cache_kicad();
-        }
-
-        let kicad_text = if let Some(ref version) = self.kicad_version {
+        let kicad_text = if let Some(ref version) = self.services.kicad_version {
             format!("KiCad {}", version)
         } else {
             "KiCad (not found)".to_string()
@@ -433,16 +408,15 @@ impl CopperForgeApp {
 
         if ui.button(egui::RichText::new(kicad_text)
             .color(egui::Color32::from_rgb(180, 255, 200))).clicked() {
-            self.show_kicad_version_modal = true;
+            self.services.show_kicad_version_modal = true;
         }
 
         ui.separator();
-        
-        // Show clock with user's preferred format
-        let time_format = if self.use_24_hour_clock { "%H:%M:%S" } else { "%I:%M:%S %p" };
+
+        let time_format = if self.services.use_24_hour_clock { "%H:%M:%S" } else { "%I:%M:%S %p" };
         let date_format = "%Y-%m-%d";
-        
-        let clock_text = if let Some(tz_name) = &self.user_timezone {
+
+        let clock_text = if let Some(tz_name) = &self.services.user_timezone {
             if let Ok(tz) = tz_name.parse::<Tz>() {
                 let now = Utc::now().with_timezone(&tz);
                 format!("{} 🕐 {} {}", now.format(date_format), now.format(time_format), tz.name())
@@ -454,39 +428,34 @@ impl CopperForgeApp {
             let now = Local::now();
             format!("{} 🕐 {}", now.format(date_format), now.format(time_format))
         };
-        
+
         ui.label(egui::RichText::new(clock_text).color(egui::Color32::from_rgb(220, 220, 220)));
     }
 
-    /// Detect KiCad version and cache the discovery method. First call probes
-    /// PATH / Flatpak / Snap (the Flatpak probe alone can take 1-3s). Subsequent
-    /// uses of `kicad-cli` reuse the cached method via `kicad_cli_command()`.
-    pub fn detect_and_cache_kicad(&mut self) {
+    /// One-shot KiCad discovery + version parse. Returns (version_string, method).
+    fn probe_kicad_cli() -> (Option<String>, Option<String>) {
         let (method, mut cmd) = match Self::find_kicad_cli() {
             Some(f) => f,
-            None => return,
+            None => return (None, None),
         };
         let output = match cmd.arg("--version").output() {
             Ok(o) if o.status.success() => o,
-            _ => return,
+            _ => return (None, Some(method)),
         };
-        if let Some(mut v) = Self::parse_kicad_version(&output.stdout, false) {
+        let version = Self::parse_kicad_version(&output.stdout, false).map(|mut v| {
             if method != "path" {
                 v = format!("{} ({})", v, method);
             }
-            self.kicad_version = Some(v);
-        }
-        self.kicad_cli_method = Some(method);
+            v
+        });
+        (version, Some(method))
     }
 
-    /// Build a `kicad-cli` Command using the cached discovery method, without
-    /// re-probing. Returns None if discovery hasn't run yet (call
-    /// `detect_and_cache_kicad()` first, or the ribbon's first-frame path).
+    /// Build a `kicad-cli` Command using the cached discovery method — no probe.
     pub fn kicad_cli_command(&self) -> Option<std::process::Command> {
-        self.kicad_cli_method.as_deref().map(Self::build_kicad_cli_command)
+        self.services.kicad_cli_method.as_deref().map(Self::build_kicad_cli_command)
     }
 
-    /// Pure constructor — no subprocess spawn. Safe to call on hot paths.
     fn build_kicad_cli_command(method: &str) -> std::process::Command {
         use std::process::Command;
         match method {
@@ -504,8 +473,6 @@ impl CopperForgeApp {
         }
     }
 
-    /// Find kicad-cli across PATH, Flatpak, and Snap — expensive probe.
-    /// Prefer `kicad_cli_command()` after `detect_and_cache_kicad()` has run.
     pub fn find_kicad_cli() -> Option<(String, std::process::Command)> {
         use std::process::Command;
 
@@ -552,13 +519,12 @@ impl CopperForgeApp {
         Some(version)
     }
 
-    /// Render the KiCad information modal
     fn render_kicad_info_modal(&self, ui: &mut egui::Ui) {
         ui.vertical_centered(|ui| {
             ui.heading("KiCad PCB Design Software");
             ui.add_space(10.0);
 
-            if let Some(ref version) = self.kicad_version {
+            if let Some(ref version) = self.services.kicad_version {
                 ui.label(egui::RichText::new(format!("Version: {}", version))
                     .size(16.0)
                     .strong());
@@ -582,35 +548,6 @@ impl CopperForgeApp {
             ui.hyperlink_to("📖 Documentation", "https://docs.kicad.org/");
             ui.hyperlink_to("💬 Forums", "https://forum.kicad.info/");
         });
-    }
-
-    /// Show the main content area (dock layout without Project tab)
-    #[allow(dead_code)]
-    fn show_main_content(&mut self, ui: &mut egui::Ui) {
-        // Clone the dock state but filter out the Project tab
-        let mut dock_state = self.dock_state.clone();
-        
-        // Create the dock layout and tab viewer
-        let mut dispatcher = std::mem::take(&mut self.dispatcher);
-        {
-            let mut tab_viewer = TabViewer { app: self, dispatcher: &mut dispatcher };
-
-            // Create custom style to match panel colors
-            let mut style = Style::from_egui(ui.ctx().style().as_ref());
-            style.dock_area_padding = None;
-            style.tab_bar.fill_tab_bar = true;
-
-            // Show the dock area but filtered to exclude Project tab
-            DockArea::new(&mut dock_state)
-                .style(style)
-                .show_add_buttons(false)
-                .show_close_buttons(true)
-                .show(ui.ctx(), &mut tab_viewer);
-        }
-        self.dispatcher = dispatcher;
-
-        // Save the updated dock state back to the app
-        self.dock_state = dock_state;
     }
 }
 
@@ -642,12 +579,10 @@ impl CopperForgeApp {
             if let Ok(json) = fs::read_to_string(&config_path) {
                 match serde_json::from_str::<DockState<Tab>>(&json) {
                     Ok(dock_state) => {
-                        // Successfully loaded dock state
                         return Some(dock_state);
                     }
                     Err(e) => {
                         eprintln!("Failed to deserialize dock state: {}", e);
-                        // Delete corrupted file
                         fs::remove_file(config_path).ok();
                     }
                 }
@@ -655,15 +590,14 @@ impl CopperForgeApp {
         }
         None
     }
-    
-    pub fn save_settings(&self) {
-        let mut config = self.project_manager.config.clone();
-        config.state = self.project_manager.state.clone(); // Save current project state!
-        config.user_timezone = self.user_timezone.clone();
-        config.use_24_hour_clock = self.use_24_hour_clock;
-        config.global_units_mils = self.global_units_mils;
 
-        // Save author/company/library settings from ProjectManagerState if it exists
+    pub fn save_settings(&self) {
+        let mut config = self.services.config.clone();
+        config.state = self.services.project_state.get();
+        config.user_timezone = self.services.user_timezone.clone();
+        config.use_24_hour_clock = self.services.use_24_hour_clock;
+        config.global_units_mils = self.services.global_units_mils;
+
         if let Some(ref manager_state) = self.project_manager_state {
             config.default_author = manager_state.new_kicad_project_author.clone();
             config.default_company = manager_state.new_kicad_project_company.clone();
@@ -671,30 +605,25 @@ impl CopperForgeApp {
             config.include_atlantix_resistors = manager_state.include_atlantix_resistors;
         }
 
-        if let Err(e) = config.save_to_file(&self.config_path) {
+        if let Err(e) = config.save_to_file(&self.services.config_path) {
             eprintln!("Failed to save settings: {}", e);
         }
     }
-    
+
     fn create_default_dock_state() -> DockState<Tab> {
-        // Load saved dock state if it exists
         if let Some(saved_dock_state) = Self::load_dock_state() {
             return saved_dock_state;
         }
 
-        // Create tabs matching the screenshot layout
         let gerber_tab = Tab::new(TabKind::GerberView, SurfaceIndex::main(), NodeIndex(0));
         let drc_tab = Tab::new(TabKind::DRC, SurfaceIndex::main(), NodeIndex(1));
         let view_settings_tab = Tab::new(TabKind::ViewSettings, SurfaceIndex::main(), NodeIndex(2));
 
-        // Left side top tabs
         let project_tab = Tab::new(TabKind::Project, SurfaceIndex::main(), NodeIndex(3));
         let settings_tab = Tab::new(TabKind::Settings, SurfaceIndex::main(), NodeIndex(5));
 
-        // Left side bottom tabs
         let projects_tab = Tab::new(TabKind::Projects, SurfaceIndex::main(), NodeIndex(6));
 
-        // Right side tabs — logger / terminal / shell share a group
         let logger_tab = Tab::new(TabKind::Logger, SurfaceIndex::main(), NodeIndex(7));
         let terminal_tab = Tab::new(TabKind::Terminal, SurfaceIndex::main(), NodeIndex(8));
         let shell_tab = Tab::new(TabKind::Shell, SurfaceIndex::main(), NodeIndex(9));
@@ -716,297 +645,219 @@ impl CopperForgeApp {
     }
 }
 
-/// Implement the eframe::App trait for CopperForgeApp
-///
-/// This implementation contains the main event loop for the application, including
-/// handling user input, updating the UI, and rendering the Gerber layer. It also contains
-/// the logic for handling the logger and displaying system information.
-/// The `update` method is called every frame and is responsible for updating the UI
-/// and rendering the Gerber layer. It also handles user input and updates the logger
-/// state. The `update` method is where most of the application logic resides.
-/// 
 impl eframe::App for CopperForgeApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // Handle system info button clicked
         let show_system_info_clicked = ctx.memory(|mem| {
             mem.data.get_temp::<bool>(egui::Id::new("show_system_info")).unwrap_or(false)
         });
-        
+
         if show_system_info_clicked {
-            // Clear the flag
             ctx.memory_mut(|mem| {
                 mem.data.remove::<bool>(egui::Id::new("show_system_info"));
             });
-            
-            // Show system info
-            let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
+            let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
             show_system_info(&logger);
         }
-        
-        // Only update coordinates when explicitly marked as dirty (not time-based)
-        if self.layer_store.is_dirty() {
-            self.layer_store.mark_clean();
+
+        if self.services.layer_store.is_dirty() {
+            self.services.layer_store.mark_clean();
         }
-        
-        
-        // Handle hotkeys first (but only if no text field has focus)
+
+        // Hotkeys (only when no text field has focus)
         let text_input_active = ctx.memory(|mem| mem.focused().is_some());
-        
+
         if !text_input_active {
             ctx.input(|i| {
-                // F key - flip board view (top/bottom)
                 if i.key_pressed(egui::Key::F) {
-                self.display_manager.showing_top = !self.display_manager.showing_top;
-                
-                // Auto-toggle layer visibility based on flip state
-                use crate::layer_store::{LayerType, Side};
-                for layer_type in LayerType::all() {
-                    let visible = match layer_type {
-                        LayerType::Copper(1) |
-                        LayerType::Silkscreen(Side::Top) |
-                        LayerType::Soldermask(Side::Top) |
-                        LayerType::Paste(Side::Top) => {
-                            self.display_manager.showing_top
-                        },
-                        LayerType::Copper(_) => {
-                            !self.display_manager.showing_top
-                        },
-                        LayerType::Silkscreen(Side::Bottom) |
-                        LayerType::Soldermask(Side::Bottom) |
-                        LayerType::Paste(Side::Bottom) => {
-                            !self.display_manager.showing_top
-                        },
-                        LayerType::MechanicalOutline => {
-                            // Leave outline visibility unchanged
-                            self.layer_store.get_visibility(layer_type)
-                        }
-                    };
-                    self.layer_store.set_visibility(layer_type, visible);
+                    self.services.display_manager.showing_top = !self.services.display_manager.showing_top;
+
+                    use crate::layer_store::{LayerType, Side};
+                    for layer_type in LayerType::all() {
+                        let visible = match layer_type {
+                            LayerType::Copper(1)
+                            | LayerType::Silkscreen(Side::Top)
+                            | LayerType::Soldermask(Side::Top)
+                            | LayerType::Paste(Side::Top) => {
+                                self.services.display_manager.showing_top
+                            }
+                            LayerType::Copper(_) => !self.services.display_manager.showing_top,
+                            LayerType::Silkscreen(Side::Bottom)
+                            | LayerType::Soldermask(Side::Bottom)
+                            | LayerType::Paste(Side::Bottom) => {
+                                !self.services.display_manager.showing_top
+                            }
+                            LayerType::MechanicalOutline => {
+                                self.services.layer_store.get_visibility(layer_type)
+                            }
+                        };
+                        self.services.layer_store.set_visibility(layer_type, visible);
+                    }
+
+                    let view_name = if self.services.display_manager.showing_top { "top" } else { "bottom" };
+                    let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
+                    logger.log_info(&format!("Flipped to {} view (F key)", view_name));
+                    self.services.layer_store.mark_dirty();
                 }
 
-                let view_name = if self.display_manager.showing_top { "top" } else { "bottom" };
-                let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
-                logger.log_info(&format!("Flipped to {} view (F key)", view_name));
-                // Mark coordinates as dirty since view changed
-                self.layer_store.mark_dirty();
-            }
-            
-            // U key - toggle units (mm/mils)
-            if i.key_pressed(egui::Key::U) {
-                self.global_units_mils = !self.global_units_mils;
-                self.sync_units_to_ecs(); // Sync to ECS units system
-                let units_name = if self.global_units_mils { "mils" } else { "mm" };
-                let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
-                logger.log_info(&format!("Toggled units to {} (U key)", units_name));
-            }
-            
-            // R key - rotate board 90 degrees clockwise
-            if i.key_pressed(egui::Key::R) {
-                // Update rotation
-                self.rotation_degrees = (self.rotation_degrees + 90.0) % 360.0;
-                
-                // Don't reset view - just mark coordinates as dirty to update rotation
-                // This keeps the view centered on the current origin
-                self.layer_store.mark_dirty();
-                
-                let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
-                logger.log_custom(
-                    project::constants::LOG_TYPE_ROTATION,
-                    &format!("Rotated board to {:.0}° (R key)", self.rotation_degrees)
-                );
+                if i.key_pressed(egui::Key::U) {
+                    self.services.global_units_mils = !self.services.global_units_mils;
+                    self.sync_units_to_ecs();
+                    let units_name = if self.services.global_units_mils { "mils" } else { "mm" };
+                    let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
+                    logger.log_info(&format!("Toggled units to {} (U key)", units_name));
                 }
-            
-            // A key - align view to grid
-            if i.key_pressed(egui::Key::A) {
-                display::align_to_grid(&mut self.view_state, &self.grid_settings);
-                
-                let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
-                logger.log_info("Aligned view to grid (A key)");
+
+                if i.key_pressed(egui::Key::R) {
+                    self.services.rotation_degrees = (self.services.rotation_degrees + 90.0) % 360.0;
+                    self.services.layer_store.mark_dirty();
+
+                    let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
+                    logger.log_custom(
+                        project::constants::LOG_TYPE_ROTATION,
+                        &format!("Rotated board to {:.0}° (R key)", self.services.rotation_degrees)
+                    );
                 }
-            
-            // M key - toggle ruler mode with latched measurement support
-            if i.key_pressed(egui::Key::M) {
-                if self.ruler_active {
-                    // Exiting measurement mode - latch the current measurement if complete
-                    if self.ruler_start.is_some() && self.ruler_end.is_some() {
-                        self.latched_measurement_start = self.ruler_start;
-                        self.latched_measurement_end = self.ruler_end;
-                    }
-                    
-                    // Clear ruler when deactivated
-                    self.ruler_active = false;
-                    self.ruler_start = None;
-                    self.ruler_end = None;
-                    self.ruler_dragging = false;
-                    
-                    let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
-                    logger.log_info("Ruler mode deactivated (M key) - measurement latched");
-                } else {
-                    // Starting new measurement mode - clear previous latched measurement
-                    self.latched_measurement_start = None;
-                    self.latched_measurement_end = None;
-                    
-                    self.ruler_active = true;
-                    
-                    let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
-                    logger.log_info("Ruler mode activated (M key) - previous measurement cleared");
+
+                if i.key_pressed(egui::Key::A) {
+                    display::align_to_grid(&mut self.services.view_state, &self.services.grid_settings);
+                    let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
+                    logger.log_info("Aligned view to grid (A key)");
                 }
-                }
-            
-            // ESC key - cancel measurement mode with latching support
-            if i.key_pressed(egui::Key::Escape) && self.ruler_active {
-                // Latch the current measurement if complete
-                if self.ruler_start.is_some() && self.ruler_end.is_some() {
-                    self.latched_measurement_start = self.ruler_start;
-                    self.latched_measurement_end = self.ruler_end;
-                    
-                    // Debug log the latched values
-                    let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
-                    if let (Some(start), Some(end)) = (self.ruler_start, self.ruler_end) {
-                        logger.log_info(&format!("Latching measurement - Start: ({:.6}, {:.6}), End: ({:.6}, {:.6})", 
-                                                start.x, start.y, end.x, end.y));
-                        let dx = end.x - start.x;
-                        let dy = end.y - start.y;
-                        logger.log_info(&format!("Latching deltas - ΔX: {:.6}, ΔY: {:.6}", dx, dy));
+
+                if i.key_pressed(egui::Key::M) {
+                    if self.services.ruler_active {
+                        if self.services.ruler_start.is_some() && self.services.ruler_end.is_some() {
+                            self.services.latched_measurement_start = self.services.ruler_start;
+                            self.services.latched_measurement_end = self.services.ruler_end;
+                        }
+                        self.services.ruler_active = false;
+                        self.services.ruler_start = None;
+                        self.services.ruler_end = None;
+                        self.services.ruler_dragging = false;
+
+                        let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
+                        logger.log_info("Ruler mode deactivated (M key) - measurement latched");
+                    } else {
+                        self.services.latched_measurement_start = None;
+                        self.services.latched_measurement_end = None;
+                        self.services.ruler_active = true;
+
+                        let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
+                        logger.log_info("Ruler mode activated (M key) - previous measurement cleared");
                     }
                 }
-                
-                // Clear ruler when deactivated
-                self.ruler_active = false;
-                self.ruler_start = None;
-                self.ruler_end = None;
-                self.ruler_dragging = false;
-                
-                let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
-                logger.log_info("Ruler mode cancelled (ESC key) - measurement latched");
+
+                if i.key_pressed(egui::Key::Escape) && self.services.ruler_active {
+                    if self.services.ruler_start.is_some() && self.services.ruler_end.is_some() {
+                        self.services.latched_measurement_start = self.services.ruler_start;
+                        self.services.latched_measurement_end = self.services.ruler_end;
+
+                        let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
+                        if let (Some(start), Some(end)) = (self.services.ruler_start, self.services.ruler_end) {
+                            logger.log_info(&format!("Latching measurement - Start: ({:.6}, {:.6}), End: ({:.6}, {:.6})",
+                                                    start.x, start.y, end.x, end.y));
+                            let dx = end.x - start.x;
+                            let dy = end.y - start.y;
+                            logger.log_info(&format!("Latching deltas - ΔX: {:.6}, ΔY: {:.6}", dx, dy));
+                        }
+                    }
+
+                    self.services.ruler_active = false;
+                    self.services.ruler_start = None;
+                    self.services.ruler_end = None;
+                    self.services.ruler_dragging = false;
+
+                    let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
+                    logger.log_info("Ruler mode cancelled (ESC key) - measurement latched");
                 }
             });
         }
-        
+
         // Project Ribbon at the top
         egui::TopBottomPanel::top("project_ribbon").show(ctx, |ui| {
             ui.horizontal(|ui| {
                 ui.spacing_mut().item_spacing.x = 10.0;
-                
-                // Project Ribbon with file selection
+
+                // Prominent current-project indicator on the far left — so a
+                // cold start with a remembered PCB is obvious at a glance.
+                let state = self.services.project_state.get();
+                let (project_label, project_color) = match state.pcb_path() {
+                    Some(p) => (
+                        format!("📄 {}", p.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_else(|| p.display().to_string())),
+                        egui::Color32::from_rgb(180, 220, 180),
+                    ),
+                    None => (
+                        "📄 (no project loaded)".to_string(),
+                        egui::Color32::from_rgb(140, 140, 140),
+                    ),
+                };
+                // Wrap in a group so vertical centering matches the other ribbon widgets.
+                ui.group(|ui| {
+                    ui.label(egui::RichText::new(project_label).color(project_color).strong());
+                });
+
                 ui.group(|ui| {
                     ui.horizontal(|ui| {
                         ui.label("📁 KiCad PCB File:");
-                        
-                        // Show current file or placeholder
-                        let current_file_text = self.project_manager.state.pcb_path()
-                            .and_then(|p| p.file_name())
-                            .map(|n| n.to_string_lossy().to_string())
-                            .unwrap_or_else(|| "No file selected".to_string());
-                        
-                        ui.label(egui::RichText::new(current_file_text).strong());
-                        
+
                         if ui.button("Browse...").clicked() {
-                            self.project_manager.open_file_dialog();
+                            self.open_pcb_file_dialog();
                         }
-                        
-                        // Handle file dialog
-                        if let Some(path_buf) = self.project_manager.update_file_dialog(ui.ctx()) {
-                            self.project_manager.state = ProjectState::PcbSelected { pcb_path: path_buf.clone() };
-                            let logger = ReactiveEventLogger::with_colors(&self.logger_state, &self.log_colors);
+
+                        if let Some(path_buf) = self.update_pcb_file_dialog(ui.ctx()) {
+                            let logger = ReactiveEventLogger::with_colors(&self.services.logger_state, &self.services.log_colors);
                             logger.log_info(&format!("Selected PCB file: {}", path_buf.display()));
                         }
                     });
                 });
-                
-                // Hotkeys menu
-                ui.menu_button("📋 Hotkeys", |ui| {
-                    ui.heading("Keyboard Shortcuts");
-                    ui.separator();
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("F");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Flip Top/Bottom view");
-                        });
-                    });
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("R");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Rotate 90° clockwise");
-                        });
-                    });
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("U");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Toggle units (mm/mils)");
-                        });
-                    });
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("A");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Align view to grid");
-                        });
-                    });
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("M");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Toggle ruler/measurement mode");
-                        });
-                    });
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("ESC");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Cancel measurement mode");
-                        });
-                    });
-                    
-                    ui.separator();
-                    ui.heading("Mouse Controls");
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("Double-click");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Center view");
-                        });
-                    });
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("Right-click + drag");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Zoom to selection");
-                        });
-                    });
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("Scroll wheel");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Zoom in/out");
-                        });
-                    });
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("Left-click + drag");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Pan view");
-                        });
-                    });
-                    
-                    ui.horizontal(|ui| {
-                        ui.label("Escape");
-                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            ui.label("Cancel zoom selection / measurement mode");
-                        });
-                    });
-                });
-                
-                // Clock in the upper right
+
+                // Right-aligned section: clock/version first (rightmost), then
+                // Hotkeys added LAST so it ends up just to the left of the clock.
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     self.show_clock_display(ui);
+                    ui.separator();
+                    ui.menu_button("📋 Hotkeys", |ui| {
+                        ui.heading("Keyboard Shortcuts");
+                        ui.separator();
+
+                        for (key, desc) in [
+                            ("F", "Flip Top/Bottom view"),
+                            ("R", "Rotate 90° clockwise"),
+                            ("U", "Toggle units (mm/mils)"),
+                            ("A", "Align view to grid"),
+                            ("M", "Toggle ruler/measurement mode"),
+                            ("ESC", "Cancel measurement mode"),
+                        ] {
+                            ui.horizontal(|ui| {
+                                ui.label(key);
+                                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                                    ui.label(desc);
+                                });
+                            });
+                        }
+
+                        ui.separator();
+                        ui.heading("Mouse Controls");
+
+                        for (key, desc) in [
+                            ("Double-click", "Center view"),
+                            ("Right-click + drag", "Zoom to selection"),
+                            ("Scroll wheel", "Zoom in/out"),
+                            ("Left-click + drag", "Pan view"),
+                            ("Escape", "Cancel zoom selection / measurement mode"),
+                        ] {
+                            ui.horizontal(|ui| {
+                                ui.label(key);
+                                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                                    ui.label(desc);
+                                });
+                            });
+                        }
+                    });
                 });
             });
         });
-        
+
         // Main dock area below the ribbon
         let mut dock_state = self.dock_state.clone();
         let mut dispatcher = std::mem::take(&mut self.dispatcher);
@@ -1026,15 +877,13 @@ impl eframe::App for CopperForgeApp {
                 .show(ctx, &mut tab_viewer);
         }
 
-        // Drain citizen lifecycle messages
         for msg in dispatcher.drain_messages() {
             self.app_messages.push(crate::messages::AppMessage::Citizen(msg));
         }
         self.dispatcher = dispatcher;
         self.dock_state = dock_state;
-        
-        // Show About modal if requested
-        if self.show_about_modal {
+
+        if self.services.show_about_modal {
             egui::Window::new("About CopperForge")
                 .collapsible(false)
                 .resizable(true)
@@ -1050,15 +899,14 @@ impl eframe::App for CopperForgeApp {
                     ui.horizontal(|ui| {
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             if ui.button("Close").clicked() {
-                                self.show_about_modal = false;
+                                self.services.show_about_modal = false;
                             }
                         });
                     });
                 });
         }
 
-        // Show KiCad Version modal if requested
-        if self.show_kicad_version_modal {
+        if self.services.show_kicad_version_modal {
             egui::Window::new("KiCad Information")
                 .collapsible(false)
                 .resizable(false)
@@ -1073,18 +921,15 @@ impl eframe::App for CopperForgeApp {
                     ui.horizontal(|ui| {
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             if ui.button("Close").clicked() {
-                                self.show_kicad_version_modal = false;
+                                self.services.show_kicad_version_modal = false;
                             }
                         });
                     });
                 });
         }
-        
-        // Save dock state to disk periodically
+
         if ctx.input(|i| i.time) % 30.0 < 0.1 {
             self.save_dock_state();
         }
     }
 }
-
-

--- a/crates/copperforge-core/src/app.rs
+++ b/crates/copperforge-core/src/app.rs
@@ -44,13 +44,18 @@ pub struct CopperForgeApp {
     pub projects_directory_dialog: egui_file_dialog::FileDialog,
     pub last_picked_projects_directory: Option<PathBuf>,
 
-    // ── Panel-owned state (temporary — migrates into citizens) ─
-    pub bom_state: Option<ui::BomPanelState>,
+    // ── Persisted citizen panels ───────────────────────────────
+    /// Persisted so panel-local state (BOM cache, terminal buffer, shell
+    /// history, etc.) survives across frames. Stateless panels (DRC,
+    /// ViewSettings, Project, Projects, Settings) are still created fresh
+    /// per frame in tabs.rs since they have nothing to carry.
+    pub bom_panel: crate::panels::BomPanel,
+    pub terminal_panel: crate::panels::TerminalPanel,
+    pub shell_panel: crate::panels::ShellPanel,
+    pub logger_panel: crate::panels::LoggerPanel,
+
+    // ── Panel-owned state (for panels not yet citizen-persisted) ─
     pub project_manager_state: Option<project_manager::ProjectManagerState>,
-    pub term_output: Vec<String>,
-    pub term_cmd_buf: String,
-    pub shell_log: Vec<String>,
-    pub shell_cmd_buf: String,
 }
 
 impl Drop for CopperForgeApp {
@@ -209,6 +214,7 @@ impl CopperForgeApp {
             latched_measurement_end: None,
             show_about_modal: false,
             show_kicad_version_modal: false,
+            bom_component_count: 0,
             config,
         };
 
@@ -236,12 +242,11 @@ impl CopperForgeApp {
             last_picked_pcb_file: None,
             projects_directory_dialog: egui_file_dialog::FileDialog::new(),
             last_picked_projects_directory: None,
-            bom_state: None,
+            bom_panel: crate::panels::BomPanel::new(egui_citizen::CitizenState::default()),
+            terminal_panel: crate::panels::TerminalPanel::new(egui_citizen::CitizenState::default()),
+            shell_panel: crate::panels::ShellPanel::new(egui_citizen::CitizenState::default()),
+            logger_panel: crate::panels::LoggerPanel::new(egui_citizen::CitizenState::default()),
             project_manager_state: None,
-            term_output: Vec::new(),
-            term_cmd_buf: String::new(),
-            shell_log: Vec::new(),
-            shell_cmd_buf: String::new(),
         };
 
         let logger = ReactiveEventLogger::with_colors(&app.services.logger_state, &app.services.log_colors);

--- a/crates/copperforge-core/src/app.rs
+++ b/crates/copperforge-core/src/app.rs
@@ -56,6 +56,41 @@ pub struct CopperForgeApp {
 
     // ── Panel-owned state (for panels not yet citizen-persisted) ─
     pub project_manager_state: Option<project_manager::ProjectManagerState>,
+
+    // ── Modal states (UI ephemeral) ─────────────────────────────
+    pub release_modal: Option<ReleaseModalState>,
+    pub project_edit_modal: Option<ProjectEditModalState>,
+}
+
+/// Form state for the Project Edit modal (opened from the Projects tab via
+/// right-click → Update).
+pub struct ProjectEditModalState {
+    pub project_id: String,
+    pub name: String,
+    pub description: String,
+    pub tags: String,
+    // Snapshot of read-only fields for display:
+    pub author: Option<String>,
+    pub company: Option<String>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub last_modified: chrono::DateTime<chrono::Utc>,
+    pub pcb_file_path: std::path::PathBuf,
+    pub releases: Vec<crate::release::Release>,
+    pub error: Option<String>,
+}
+
+/// Form state for the Release modal.
+pub struct ReleaseModalState {
+    pub rev_tag: String,
+    pub description: String,
+    pub changes: String,
+    pub include_date_in_name: bool,
+    pub include_notes_in_zip: bool,
+    pub error: Option<String>,
+    /// True when opened via right-click → Regenerate on an existing rev.
+    /// Skips the tag-collision check and updates the existing Release entry
+    /// in place rather than appending a new one.
+    pub overwrite_existing: bool,
 }
 
 impl Drop for CopperForgeApp {
@@ -247,6 +282,8 @@ impl CopperForgeApp {
             shell_panel: crate::panels::ShellPanel::new(egui_citizen::CitizenState::default()),
             logger_panel: crate::panels::LoggerPanel::new(egui_citizen::CitizenState::default()),
             project_manager_state: None,
+            release_modal: None,
+            project_edit_modal: None,
         };
 
         let logger = ReactiveEventLogger::with_colors(&app.services.logger_state, &app.services.log_colors);
@@ -603,12 +640,9 @@ impl CopperForgeApp {
         config.use_24_hour_clock = self.services.use_24_hour_clock;
         config.global_units_mils = self.services.global_units_mils;
 
-        if let Some(ref manager_state) = self.project_manager_state {
-            config.default_author = manager_state.new_kicad_project_author.clone();
-            config.default_company = manager_state.new_kicad_project_company.clone();
-            config.include_kiverse = manager_state.include_kiverse;
-            config.include_atlantix_resistors = manager_state.include_atlantix_resistors;
-        }
+        // Author / company / kiverse settings are now sourced from defaults in
+        // ProjectConfig directly (set via the Shell `set` command or edited in
+        // ~/.config/copperforge/project_config.json). They're not mutated here.
 
         if let Err(e) = config.save_to_file(&self.services.config_path) {
             eprintln!("Failed to save settings: {}", e);
@@ -933,8 +967,519 @@ impl eframe::App for CopperForgeApp {
                 });
         }
 
+        self.show_release_modal(ctx);
+        self.handle_project_edit_open(ctx);
+        self.show_project_edit_modal(ctx);
+        self.handle_release_open_intent(ctx);
+
         if ctx.input(|i| i.time) % 30.0 < 0.1 {
             self.save_dock_state();
         }
     }
+}
+
+impl CopperForgeApp {
+    /// Render the release modal and handle Create/Cancel actions.
+    fn show_release_modal(&mut self, ctx: &egui::Context) {
+        if self.release_modal.is_none() {
+            return;
+        }
+
+        let mut close = false;
+        let mut trigger_create = false;
+
+        let window_title = if self.release_modal.as_ref().map(|m| m.overwrite_existing).unwrap_or(false) {
+            "🔄 Regenerate Release"
+        } else {
+            "🚀 Create Release"
+        };
+
+        egui::Window::new(window_title)
+            .collapsible(false)
+            .resizable(true)
+            .default_size(egui::vec2(520.0, 440.0))
+            .default_pos(egui::pos2(
+                ctx.content_rect().center().x - 260.0,
+                ctx.content_rect().center().y - 220.0,
+            ))
+            .show(ctx, |ui| {
+                let modal = self.release_modal.as_mut().unwrap();
+
+                if modal.overwrite_existing {
+                    ui.colored_label(
+                        egui::Color32::from_rgb(230, 200, 120),
+                        format!("⚠ Regenerating '{}' — existing zip + notes will be overwritten.", modal.rev_tag),
+                    );
+                    ui.add_space(6.0);
+                }
+
+                ui.label("Archive gerbers + drill files as a tagged release under");
+                ui.monospace("<project>/outputs/<rev_tag>/");
+                ui.add_space(8.0);
+
+                egui::Grid::new("release_modal_grid")
+                    .num_columns(2)
+                    .spacing([12.0, 6.0])
+                    .show(ui, |ui| {
+                        ui.label("Rev tag:");
+                        ui.text_edit_singleline(&mut modal.rev_tag);
+                        ui.end_row();
+
+                        ui.label("Include date in filename:");
+                        ui.checkbox(&mut modal.include_date_in_name, "e.g. _18Apr2026");
+                        ui.end_row();
+
+                        ui.label("Include RELEASE_NOTES.md in zip:");
+                        ui.checkbox(&mut modal.include_notes_in_zip, "(off = client-only notes)");
+                        ui.end_row();
+                    });
+
+                ui.add_space(8.0);
+                ui.label("Description (what this board is about):");
+                ui.add(egui::TextEdit::multiline(&mut modal.description)
+                    .desired_width(f32::INFINITY)
+                    .desired_rows(3));
+
+                ui.add_space(8.0);
+                ui.label("Changes from previous version:");
+                ui.add(egui::TextEdit::multiline(&mut modal.changes)
+                    .desired_width(f32::INFINITY)
+                    .desired_rows(6)
+                    .hint_text("- changed footprint on U2\n- routed power plane stitching\n- ..."));
+
+                if let Some(ref err) = modal.error {
+                    ui.add_space(6.0);
+                    ui.colored_label(egui::Color32::from_rgb(245, 120, 140), err);
+                }
+
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    let go_label = if modal.overwrite_existing { "Regenerate" } else { "Create Release" };
+                    if ui.button(go_label).clicked() {
+                        trigger_create = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        close = true;
+                    }
+                });
+            });
+
+        if trigger_create {
+            self.execute_release_from_modal();
+        }
+        if close {
+            self.release_modal = None;
+        }
+    }
+
+    /// Validate + run the create-release flow using the modal's current state.
+    fn execute_release_from_modal(&mut self) {
+        // Clone modal data out so we can mutably borrow self for the release call.
+        let (modal, overwrite) = match self.release_modal.as_ref() {
+            Some(m) => (m.clone_for_exec(), m.overwrite_existing),
+            None => return,
+        };
+
+        // Validate
+        if modal.rev_tag.trim().is_empty() {
+            if let Some(ref mut m) = self.release_modal {
+                m.error = Some("Rev tag cannot be empty".into());
+            }
+            return;
+        }
+
+        // Require project record + Ready state
+        use crate::project::ProjectState;
+        let (pcb_path, gerber_dir) = match self.services.project_state.get() {
+            ProjectState::Ready { pcb_path, gerber_dir, .. } => (pcb_path, gerber_dir),
+            _ => {
+                if let Some(ref mut m) = self.release_modal {
+                    m.error = Some("Gerbers must be loaded (state: Ready) before releasing.".into());
+                }
+                return;
+            }
+        };
+
+        // Collision check against existing releases — skipped in regenerate mode.
+        if !overwrite {
+            let current_pm_state = self.project_manager_state.as_ref();
+            let has_collision = current_pm_state
+                .and_then(|s| s.current_project.as_ref())
+                .map(|p| p.releases.iter().any(|r| r.tag == modal.rev_tag))
+                .unwrap_or(false);
+            if has_collision {
+                if let Some(ref mut m) = self.release_modal {
+                    m.error = Some(format!(
+                        "Release '{}' already exists. Right-click the rev in the Projects tree → Regenerate.",
+                        modal.rev_tag
+                    ));
+                }
+                return;
+            }
+        }
+
+        // Build kicad-cli Command for drill export
+        let Some(kicad_cli) = self.kicad_cli_command() else {
+            if let Some(ref mut m) = self.release_modal {
+                m.error = Some("kicad-cli not discovered at startup — cannot export drill files.".into());
+            }
+            return;
+        };
+
+        let os_description = Self::build_os_description();
+        let kicad_version = self.services.kicad_version.clone();
+        let logger_state = self.services.logger_state.clone();
+        let log_colors = self.services.log_colors.clone();
+        let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
+
+        let req = crate::release::ReleaseRequest {
+            rev_tag: modal.rev_tag.clone(),
+            description: modal.description.clone(),
+            changes: modal.changes.clone(),
+            include_date_in_name: modal.include_date_in_name,
+            include_notes_in_zip: modal.include_notes_in_zip,
+        };
+        let sources = crate::release::ReleaseSources {
+            pcb_path: &pcb_path,
+            gerber_dir: &gerber_dir,
+            kicad_cli,
+            kicad_version,
+            os_description,
+        };
+
+        logger.log_info(&format!("Creating release '{}'...", modal.rev_tag));
+        match crate::release::create_release(&req, sources, &logger) {
+            Ok(outcome) => {
+                // Persist: either append (new release) or replace-in-place
+                // (regenerate). Also update the tree-rendering cache so the
+                // new/updated rev shows up immediately under outputs/.
+                if let Some(ref mut pm) = self.project_manager_state {
+                    let project_id_opt = pm.current_project.as_ref().map(|p| p.metadata.id.clone());
+                    if let Some(ref mut current) = pm.current_project {
+                        if overwrite {
+                            if let Some(slot) = current.releases.iter_mut().find(|r| r.tag == outcome.release.tag) {
+                                *slot = outcome.release.clone();
+                            } else {
+                                // Cache/DB had drifted; just append.
+                                current.releases.push(outcome.release.clone());
+                            }
+                        } else {
+                            current.releases.push(outcome.release.clone());
+                        }
+                        current.metadata.last_modified = chrono::Utc::now();
+                        if let Err(e) = self.services.project_db.save_project(current) {
+                            logger.log_error(&format!("Release written to disk but DB save failed: {}", e));
+                        }
+                    }
+                    if let Some(id) = project_id_opt {
+                        if overwrite {
+                            let tag = outcome.release.tag.clone();
+                            let entry = pm.project_releases.entry(id).or_default();
+                            if let Some(slot) = entry.iter_mut().find(|r| r.tag == tag) {
+                                *slot = outcome.release.clone();
+                            } else {
+                                entry.push(outcome.release.clone());
+                            }
+                        } else {
+                            pm.record_release(&id, outcome.release.clone());
+                        }
+                    }
+                }
+                logger.log_info(&format!("Release '{}' complete: {}", outcome.release.tag, outcome.release.archive_path.display()));
+                self.release_modal = None;
+            }
+            Err(e) => {
+                logger.log_error(&format!("Release failed: {}", e));
+                if let Some(ref mut m) = self.release_modal {
+                    m.error = Some(e);
+                }
+            }
+        }
+    }
+
+    fn build_os_description() -> String {
+        let mut d = crate::platform::details::Details::new();
+        d.get_os();
+        if d.name.is_empty() {
+            "(unknown OS)".into()
+        } else {
+            format!("{} (kernel {})", d.name, d.kernel)
+        }
+    }
+
+    // ─── Project Edit modal ────────────────────────────────────────
+
+    /// Called from the update() pass. Picks up the "open_project_edit_modal"
+    /// memory key set by the Projects tab's right-click → Update handler and
+    /// seeds `project_edit_modal` from the DB's full ProjectData record.
+    fn handle_project_edit_open(&mut self, ctx: &egui::Context) {
+        let pid = ctx.memory(|mem| {
+            mem.data.get_temp::<String>(egui::Id::new("open_project_edit_modal"))
+        });
+        let Some(pid) = pid else { return; };
+        ctx.memory_mut(|mem| {
+            mem.data.remove::<String>(egui::Id::new("open_project_edit_modal"));
+        });
+
+        // Load the full ProjectData so the modal can show releases + kicad_pro
+        // metadata (author, company).
+        let data = match self.services.project_db.load_project(&pid) {
+            Ok(Some(d)) => d,
+            _ => return,
+        };
+        let meta = crate::project_manager::kicad_metadata::get_kicad_pro_path(&data.metadata.pcb_file_path)
+            .and_then(|pro_path| {
+                if pro_path.exists() {
+                    crate::project_manager::kicad_metadata::read_kicad_metadata(&pro_path).ok()
+                } else {
+                    None
+                }
+            });
+        let (author, company) = match meta {
+            Some(m) => (m.author, m.company),
+            None => (None, None),
+        };
+
+        self.project_edit_modal = Some(ProjectEditModalState {
+            project_id: data.metadata.id.clone(),
+            name: data.metadata.name.clone(),
+            description: data.metadata.description.clone(),
+            tags: data.metadata.tags.join(", "),
+            author,
+            company,
+            created_at: data.metadata.created_at,
+            last_modified: data.metadata.last_modified,
+            pcb_file_path: data.metadata.pcb_file_path.clone(),
+            releases: data.releases.clone(),
+            error: None,
+        });
+    }
+
+    fn show_project_edit_modal(&mut self, ctx: &egui::Context) {
+        if self.project_edit_modal.is_none() { return; }
+        let mut close = false;
+        let mut save = false;
+
+        egui::Window::new("✎ Project Details")
+            .collapsible(false)
+            .resizable(true)
+            .default_size(egui::vec2(560.0, 520.0))
+            .default_pos(egui::pos2(
+                ctx.content_rect().center().x - 280.0,
+                ctx.content_rect().center().y - 260.0,
+            ))
+            .show(ctx, |ui| {
+                let modal = self.project_edit_modal.as_mut().unwrap();
+
+                egui::Grid::new("project_edit_grid_meta")
+                    .num_columns(2)
+                    .spacing([12.0, 6.0])
+                    .show(ui, |ui| {
+                        ui.label(egui::RichText::new("PCB file:").strong());
+                        ui.monospace(modal.pcb_file_path.display().to_string());
+                        ui.end_row();
+
+                        ui.label(egui::RichText::new("Author:").strong());
+                        ui.label(modal.author.as_deref().unwrap_or("(not set in .kicad_pro)"));
+                        ui.end_row();
+
+                        ui.label(egui::RichText::new("Company:").strong());
+                        ui.label(modal.company.as_deref().unwrap_or("(not set in .kicad_pro)"));
+                        ui.end_row();
+
+                        ui.label(egui::RichText::new("Created:").strong());
+                        ui.label(modal.created_at.format("%Y-%m-%d %H:%M UTC").to_string());
+                        ui.end_row();
+
+                        ui.label(egui::RichText::new("Last Modified:").strong());
+                        ui.label(modal.last_modified.format("%Y-%m-%d %H:%M UTC").to_string());
+                        ui.end_row();
+                    });
+
+                ui.add_space(10.0);
+                ui.label(egui::RichText::new("Editable fields").strong());
+
+                egui::Grid::new("project_edit_grid_edit")
+                    .num_columns(2)
+                    .spacing([12.0, 6.0])
+                    .show(ui, |ui| {
+                        ui.label("Name:");
+                        ui.text_edit_singleline(&mut modal.name);
+                        ui.end_row();
+
+                        ui.label("Tags:");
+                        ui.text_edit_singleline(&mut modal.tags);
+                        ui.end_row();
+                    });
+
+                ui.add_space(6.0);
+                ui.label("Description:");
+                ui.add(egui::TextEdit::multiline(&mut modal.description)
+                    .desired_width(f32::INFINITY)
+                    .desired_rows(5));
+
+                ui.add_space(10.0);
+                ui.collapsing(format!("Releases ({})", modal.releases.len()), |ui| {
+                    if modal.releases.is_empty() {
+                        ui.label(egui::RichText::new("No releases yet. Use 🚀 Release on the Gerber Viewer ribbon.").italics());
+                    } else {
+                        for rel in &modal.releases {
+                            ui.horizontal(|ui| {
+                                ui.monospace(&rel.tag);
+                                ui.label(rel.created_at.format("%Y-%m-%d").to_string());
+                                ui.label(egui::RichText::new(rel.archive_path.display().to_string()).small().weak());
+                            });
+                        }
+                    }
+                });
+
+                if let Some(ref err) = modal.error {
+                    ui.add_space(6.0);
+                    ui.colored_label(egui::Color32::from_rgb(245, 120, 140), err);
+                }
+
+                ui.add_space(12.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Save").clicked() { save = true; }
+                    if ui.button("Cancel").clicked() { close = true; }
+                });
+            });
+
+        if save {
+            self.save_project_edit_modal();
+        }
+        if close {
+            self.project_edit_modal = None;
+        }
+    }
+
+    fn save_project_edit_modal(&mut self) {
+        let modal = match self.project_edit_modal.as_ref() {
+            Some(m) => (m.project_id.clone(), m.name.clone(), m.description.clone(), m.tags.clone(), m.pcb_file_path.clone()),
+            None => return,
+        };
+        let (pid, name, description, tags_str, pcb_path) = modal;
+
+        if name.trim().is_empty() {
+            if let Some(ref mut m) = self.project_edit_modal {
+                m.error = Some("Name cannot be empty".into());
+            }
+            return;
+        }
+
+        let tags: Vec<String> = tags_str
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        let logger_state = self.services.logger_state.clone();
+        let log_colors = self.services.log_colors.clone();
+        let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
+
+        // Update DB record via ProjectManagerState (keeps its project_list in sync).
+        let result = if let Some(ref mut pm) = self.project_manager_state {
+            pm.update_project(&pid, name.clone(), description.clone(), tags)
+        } else {
+            return;
+        };
+
+        match result {
+            Ok(()) => {
+                logger.log_info(&format!("Saved project: {}", name));
+                if let Some(pro_path) = crate::project_manager::kicad_metadata::get_kicad_pro_path(&pcb_path) {
+                    if pro_path.exists() {
+                        if let Err(e) = crate::ui::projects_panel::update_kicad_description(&pro_path, &description) {
+                            logger.log_warning(&format!("Could not update .kicad_pro description: {}", e));
+                        } else {
+                            logger.log_info("Updated description in .kicad_pro");
+                        }
+                    }
+                }
+                self.project_edit_modal = None;
+            }
+            Err(e) => {
+                if let Some(ref mut m) = self.project_edit_modal {
+                    m.error = Some(format!("Save failed: {}", e));
+                }
+            }
+        }
+    }
+
+    // ─── Release right-click → open folder ─────────────────────────
+
+    /// Pick up "open_release_intent" (value: "proj_X:rev:rev_01") and open the
+    /// containing release dir via xdg-open / open / explorer.
+    fn handle_release_open_intent(&self, ctx: &egui::Context) {
+        let intent = ctx.memory(|mem| {
+            mem.data.get_temp::<String>(egui::Id::new("open_release_intent"))
+        });
+        let Some(intent) = intent else { return; };
+        ctx.memory_mut(|mem| {
+            mem.data.remove::<String>(egui::Id::new("open_release_intent"));
+        });
+
+        // Parse "proj_X:rev:rev_01" → (project_id, rev_tag).
+        let mut parts = intent.splitn(3, ':');
+        let project_id = match parts.next() { Some(s) => s, None => return };
+        let _marker = parts.next(); // "rev"
+        let rev_tag = match parts.next() { Some(s) => s, None => return };
+
+        let logger_state = self.services.logger_state.clone();
+        let log_colors = self.services.log_colors.clone();
+        let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
+
+        // Find the release in the cache to get its archive path.
+        let releases = self.project_manager_state
+            .as_ref()
+            .and_then(|pm| pm.project_releases.get(project_id))
+            .cloned()
+            .unwrap_or_default();
+        let release = releases.iter().find(|r| r.tag == rev_tag);
+        let Some(release) = release else {
+            logger.log_error(&format!("Release {} not found in cache", rev_tag));
+            return;
+        };
+        let rev_dir = match release.archive_path.parent() {
+            Some(d) => d,
+            None => {
+                logger.log_error("Release archive path has no parent dir");
+                return;
+            }
+        };
+
+        #[cfg(target_os = "linux")]
+        let opener = "xdg-open";
+        #[cfg(target_os = "macos")]
+        let opener = "open";
+        #[cfg(target_os = "windows")]
+        let opener = "explorer";
+
+        match std::process::Command::new(opener).arg(rev_dir).spawn() {
+            Ok(_) => logger.log_info(&format!("Opened release folder: {}", rev_dir.display())),
+            Err(e) => logger.log_error(&format!("Failed to open {}: {}", rev_dir.display(), e)),
+        }
+    }
+}
+
+impl crate::app::ReleaseModalState {
+    /// Snapshot the values needed to execute the release, avoiding borrow
+    /// conflicts with `self.release_modal` during the call.
+    fn clone_for_exec(&self) -> ReleaseModalSnapshot {
+        ReleaseModalSnapshot {
+            rev_tag: self.rev_tag.clone(),
+            description: self.description.clone(),
+            changes: self.changes.clone(),
+            include_date_in_name: self.include_date_in_name,
+            include_notes_in_zip: self.include_notes_in_zip,
+        }
+    }
+}
+
+struct ReleaseModalSnapshot {
+    rev_tag: String,
+    description: String,
+    changes: String,
+    include_date_in_name: bool,
+    include_notes_in_zip: bool,
 }

--- a/crates/copperforge-core/src/export/mod.rs
+++ b/crates/copperforge-core/src/export/mod.rs
@@ -14,7 +14,7 @@ pub struct PngExporter;
 impl PngExporter {
     /// Export each layer in quadrant view as a separate PNG file
     pub fn export_quadrant_layers(app: &mut CopperForgeApp, output_dir: &PathBuf, width: u32, height: u32) -> Result<Vec<PathBuf>, String> {
-        if !app.display_manager.quadrant_view_enabled {
+        if !app.services.display_manager.quadrant_view_enabled {
             return Err("Quadrant view must be enabled for layer export".to_string());
         }
 
@@ -22,7 +22,7 @@ impl PngExporter {
         
         // Get mechanical outline layer - this defines the consistent bounding box for all exports
         let (mechanical_outline_gerber, master_bbox) = {
-            let mech_layer = app.layer_store.find(LayerType::MechanicalOutline)
+            let mech_layer = app.services.layer_store.find(LayerType::MechanicalOutline)
                 .ok_or("Mechanical outline layer is required for consistent PNG export boundaries")?;
             let gerber_layer = mech_layer.gerber.clone();
             let bbox = Self::calculate_master_bounding_box(app, &gerber_layer)?;
@@ -33,9 +33,9 @@ impl PngExporter {
 
         // Collect visible layers data first to avoid borrowing conflicts
         let mut layers_to_export = Vec::new();
-        for layer in app.layer_store.layers.iter() {
+        for layer in app.services.layer_store.layers.iter() {
             if layer.visible && layer.layer_type != LayerType::MechanicalOutline {
-                if layer.layer_type.should_render(app.display_manager.showing_top) {
+                if layer.layer_type.should_render(app.services.display_manager.showing_top) {
                     layers_to_export.push((layer.layer_type, layer.gerber.clone()));
                 }
             }
@@ -163,7 +163,7 @@ impl PngExporter {
         // Note: Layer positions are managed by the DisplayManager
         
         // Get quadrant offset for this layer type - this is the key positioning info
-        let quadrant_offset = app.display_manager.get_quadrant_offset(layer_type);
+        let quadrant_offset = app.services.display_manager.get_quadrant_offset(layer_type);
         
         println!("🎯 Exporting {} with quadrant offset: ({:.1}, {:.1})", 
                 layer_type.display_name(), quadrant_offset.x, quadrant_offset.y);
@@ -308,21 +308,21 @@ impl PngExporter {
         let original_bbox = gerber_layer.bounding_box().clone();
         
         // Get quadrant offset for this layer type
-        let quadrant_offset = app.display_manager.get_quadrant_offset(layer_type);
+        let quadrant_offset = app.services.display_manager.get_quadrant_offset(layer_type);
         
         // Calculate combined offset
         let combined_offset = VectorOffset {
-            x: app.display_manager.center_offset.x + quadrant_offset.x,
-            y: app.display_manager.center_offset.y + quadrant_offset.y,
+            x: app.services.display_manager.center_offset.x + quadrant_offset.x,
+            y: app.services.display_manager.center_offset.y + quadrant_offset.y,
         };
         
         // Create transform similar to what's used in rendering
-        let origin: Vector2<f64> = app.display_manager.center_offset.clone().into();
+        let origin: Vector2<f64> = app.services.display_manager.center_offset.clone().into();
         let offset: Vector2<f64> = combined_offset.into();
         
         let transform = GerberTransform {
-            rotation: app.rotation_degrees.to_radians(),
-            mirroring: app.display_manager.mirroring.clone().into(),
+            rotation: app.services.rotation_degrees.to_radians(),
+            mirroring: app.services.display_manager.mirroring.clone().into(),
             origin: origin - offset,
             offset,
             scale: 1.0,
@@ -538,7 +538,7 @@ impl PngExporter {
         ) * 0.95; // Add margin
 
         // Get quadrant offset for centering
-        let quadrant_offset = app.display_manager.get_quadrant_offset(layer_type);
+        let quadrant_offset = app.services.display_manager.get_quadrant_offset(layer_type);
         let center_x = bbox.center().x + quadrant_offset.x;
         let center_y = bbox.center().y + quadrant_offset.y;
 

--- a/crates/copperforge-core/src/panels/bom.rs
+++ b/crates/copperforge-core/src/panels/bom.rs
@@ -5,6 +5,6 @@ citizen_panel!(BomPanel, "bom");
 
 impl BomPanel {
     pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
-        crate::ui::show_bom_panel(ui, app, &app.logger_state.clone(), &app.log_colors.clone());
+        crate::ui::show_bom_panel(ui, app, &app.services.logger_state.clone(), &app.services.log_colors.clone());
     }
 }

--- a/crates/copperforge-core/src/panels/bom.rs
+++ b/crates/copperforge-core/src/panels/bom.rs
@@ -1,10 +1,12 @@
 use egui_citizen::{Citizen, CitizenId, CitizenState};
 use super::citizen_panel;
 
-citizen_panel!(BomPanel, "bom");
+citizen_panel!(BomPanel, "bom",
+    state: Option<crate::ui::BomPanelState> = None
+);
 
 impl BomPanel {
-    pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
-        crate::ui::show_bom_panel(ui, app, &app.services.logger_state.clone(), &app.services.log_colors.clone());
+    pub fn show(&mut self, ui: &mut egui::Ui, services: &mut crate::services::SharedServices) {
+        crate::ui::show_bom_panel(ui, &mut self.state, services);
     }
 }

--- a/crates/copperforge-core/src/panels/drc.rs
+++ b/crates/copperforge-core/src/panels/drc.rs
@@ -5,6 +5,6 @@ citizen_panel!(DrcPanel, "drc");
 
 impl DrcPanel {
     pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
-        crate::ui::show_drc_panel(ui, app, &app.logger_state.clone(), &app.log_colors.clone());
+        crate::ui::show_drc_panel(ui, app, &app.services.logger_state.clone(), &app.services.log_colors.clone());
     }
 }

--- a/crates/copperforge-core/src/panels/logger.rs
+++ b/crates/copperforge-core/src/panels/logger.rs
@@ -13,9 +13,9 @@ use crate::theme::TokyoNight;
 citizen_panel!(LoggerPanel, "logger");
 
 impl LoggerPanel {
-    pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
-        let state = app.services.logger_state.get();
-        let colors = app.services.log_colors.get();
+    pub fn show(&self, ui: &mut egui::Ui, services: &mut crate::services::SharedServices) {
+        let state = services.logger_state.get();
+        let colors = services.log_colors.get();
 
         let frame = egui::Frame::new()
             .fill(TokyoNight::BG_DARK)
@@ -35,7 +35,7 @@ impl LoggerPanel {
                 );
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     if ui.small_button("Clear").clicked() {
-                        app.services.logger_state.lock().clear_logs();
+                        services.logger_state.lock().clear_logs();
                     }
                 });
             });

--- a/crates/copperforge-core/src/panels/logger.rs
+++ b/crates/copperforge-core/src/panels/logger.rs
@@ -14,8 +14,8 @@ citizen_panel!(LoggerPanel, "logger");
 
 impl LoggerPanel {
     pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
-        let state = app.logger_state.get();
-        let colors = app.log_colors.get();
+        let state = app.services.logger_state.get();
+        let colors = app.services.log_colors.get();
 
         let frame = egui::Frame::new()
             .fill(TokyoNight::BG_DARK)
@@ -35,7 +35,7 @@ impl LoggerPanel {
                 );
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     if ui.small_button("Clear").clicked() {
-                        app.logger_state.lock().clear_logs();
+                        app.services.logger_state.lock().clear_logs();
                     }
                 });
             });

--- a/crates/copperforge-core/src/panels/project.rs
+++ b/crates/copperforge-core/src/panels/project.rs
@@ -5,6 +5,6 @@ citizen_panel!(ProjectPanel, "project");
 
 impl ProjectPanel {
     pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
-        crate::ui::show_project_panel(ui, app, &app.logger_state.clone(), &app.log_colors.clone());
+        crate::ui::show_project_panel(ui, app, &app.services.logger_state.clone(), &app.services.log_colors.clone());
     }
 }

--- a/crates/copperforge-core/src/panels/projects.rs
+++ b/crates/copperforge-core/src/panels/projects.rs
@@ -5,6 +5,6 @@ citizen_panel!(ProjectsPanel, "projects");
 
 impl ProjectsPanel {
     pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
-        crate::ui::show_projects_panel(ui, app, &app.logger_state.clone(), &app.log_colors.clone());
+        crate::ui::show_projects_panel(ui, app, &app.services.logger_state.clone(), &app.services.log_colors.clone());
     }
 }

--- a/crates/copperforge-core/src/panels/settings.rs
+++ b/crates/copperforge-core/src/panels/settings.rs
@@ -5,6 +5,6 @@ citizen_panel!(SettingsPanel, "settings");
 
 impl SettingsPanel {
     pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
-        crate::ui::show_settings_panel(ui, app, &app.logger_state.clone(), &app.log_colors.clone());
+        crate::ui::show_settings_panel(ui, app, &app.services.logger_state.clone(), &app.services.log_colors.clone());
     }
 }

--- a/crates/copperforge-core/src/panels/shell.rs
+++ b/crates/copperforge-core/src/panels/shell.rs
@@ -152,7 +152,7 @@ fn env_lines(app: &crate::CopperForgeApp) -> Vec<String> {
     let mut lines = vec!["KiCad:".into()];
     lines.push(format!(
         "  version          = {}",
-        app.kicad_version.as_deref().unwrap_or("(not detected)")
+        app.services.kicad_version.as_deref().unwrap_or("(not detected)")
     ));
 
     // Any KICAD_* env vars that are actually set — skip the hardcoded guesswork.
@@ -182,13 +182,13 @@ fn status_lines(app: &crate::CopperForgeApp) -> Vec<String> {
 
     lines.push(format!(
         "  PCB file        = {}",
-        app.project_manager.state.pcb_path()
+        app.services.project_state.get().pcb_path()
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| "(none)".into())
     ));
     lines.push(format!(
         "  Gerber layers   = {}",
-        app.layer_store.layers.len()
+        app.services.layer_store.layers.len()
     ));
     lines.push(format!(
         "  BOM components  = {}",
@@ -196,11 +196,11 @@ fn status_lines(app: &crate::CopperForgeApp) -> Vec<String> {
     ));
     lines.push(format!(
         "  Units           = {}",
-        if app.global_units_mils { "mils" } else { "mm" }
+        if app.services.global_units_mils { "mils" } else { "mm" }
     ));
     lines.push(format!(
         "  KiCad           = {}",
-        app.kicad_version.as_deref().unwrap_or("(not detected)")
+        app.services.kicad_version.as_deref().unwrap_or("(not detected)")
     ));
     lines
 }

--- a/crates/copperforge-core/src/panels/shell.rs
+++ b/crates/copperforge-core/src/panels/shell.rs
@@ -7,15 +7,19 @@ use egui::RichText;
 use egui_citizen::{Citizen, CitizenId, CitizenState};
 
 use super::citizen_panel;
+use crate::services::SharedServices;
 use crate::theme::TokyoNight;
 
 const PROMPT: &str = "forge> ";
 const INPUT_ID: &str = "shell_input";
 
-citizen_panel!(ShellPanel, "shell");
+citizen_panel!(ShellPanel, "shell",
+    log: Vec<String> = Vec::new(),
+    cmd_buf: String = String::new()
+);
 
 impl ShellPanel {
-    pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
+    pub fn show(&mut self, ui: &mut egui::Ui, services: &mut SharedServices) {
         let frame = egui::Frame::new()
             .fill(TokyoNight::BG_DARK)
             .inner_margin(8.0);
@@ -29,8 +33,8 @@ impl ShellPanel {
                 .auto_shrink([false; 2])
                 .stick_to_bottom(true)
                 .show(ui, |ui| {
-                    let lines: Vec<String> = app.shell_log.clone();
-                    for line in lines.iter() {
+                    let snapshot: Vec<String> = self.log.clone();
+                    for line in snapshot.iter() {
                         render_line(ui, line);
                     }
 
@@ -43,7 +47,7 @@ impl ShellPanel {
                                 .strong(),
                         );
                         let response = ui.add(
-                            egui::TextEdit::singleline(&mut app.shell_cmd_buf)
+                            egui::TextEdit::singleline(&mut self.cmd_buf)
                                 .id(text_id)
                                 .desired_width(ui.available_width())
                                 .font(egui::TextStyle::Monospace)
@@ -52,19 +56,19 @@ impl ShellPanel {
                         );
 
                         if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                            let input = app.shell_cmd_buf.trim().to_string();
+                            let input = self.cmd_buf.trim().to_string();
                             if !input.is_empty() {
                                 if input == "clear" || input == "cls" {
-                                    app.shell_log.clear();
+                                    self.log.clear();
                                 } else {
-                                    app.shell_log.push(format!("{PROMPT}{input}"));
-                                    let output = execute_command(&input, app);
+                                    self.log.push(format!("{PROMPT}{input}"));
+                                    let output = execute_command(&input, services);
                                     for line in output {
-                                        app.shell_log.push(line);
+                                        self.log.push(line);
                                     }
                                 }
                             }
-                            app.shell_cmd_buf.clear();
+                            self.cmd_buf.clear();
                             ui.memory_mut(|m| m.request_focus(text_id));
                         }
 
@@ -86,7 +90,7 @@ fn render_line(ui: &mut egui::Ui, line: &str) {
     );
 }
 
-fn execute_command(input: &str, app: &crate::CopperForgeApp) -> Vec<String> {
+fn execute_command(input: &str, services: &SharedServices) -> Vec<String> {
     let parts: Vec<&str> = input.split_whitespace().collect();
     let cmd = parts.first().map(|s| s.to_lowercase()).unwrap_or_default();
 
@@ -106,8 +110,8 @@ fn execute_command(input: &str, app: &crate::CopperForgeApp) -> Vec<String> {
         ],
         "ver" | "version" => version_lines(),
         "info" | "system" | "sysinfo" => info_lines(),
-        "status" | "state" => status_lines(app),
-        "env" => env_lines(app),
+        "status" | "state" => status_lines(services),
+        "env" => env_lines(services),
         "sh" => {
             if parts.len() > 1 {
                 let shell_cmd = parts[1..].join(" ");
@@ -133,7 +137,6 @@ fn execute_command(input: &str, app: &crate::CopperForgeApp) -> Vec<String> {
 }
 
 fn version_lines() -> Vec<String> {
-    // Same content the Logger shows at startup — welcome banner + dependency versions.
     let mut banner = crate::platform::banner::Banner::new();
     banner.format();
     banner.message
@@ -148,14 +151,13 @@ fn info_lines() -> Vec<String> {
     details.format_os().lines().map(|s| s.to_string()).collect()
 }
 
-fn env_lines(app: &crate::CopperForgeApp) -> Vec<String> {
+fn env_lines(services: &SharedServices) -> Vec<String> {
     let mut lines = vec!["KiCad:".into()];
     lines.push(format!(
         "  version          = {}",
-        app.services.kicad_version.as_deref().unwrap_or("(not detected)")
+        services.kicad_version.as_deref().unwrap_or("(not detected)")
     ));
 
-    // Any KICAD_* env vars that are actually set — skip the hardcoded guesswork.
     let mut kicad_vars: Vec<(String, String)> = std::env::vars()
         .filter(|(k, _)| k.starts_with("KICAD"))
         .collect();
@@ -177,30 +179,30 @@ fn env_lines(app: &crate::CopperForgeApp) -> Vec<String> {
     lines
 }
 
-fn status_lines(app: &crate::CopperForgeApp) -> Vec<String> {
+fn status_lines(services: &SharedServices) -> Vec<String> {
     let mut lines = vec!["CopperForge Status:".into()];
 
     lines.push(format!(
         "  PCB file        = {}",
-        app.services.project_state.get().pcb_path()
+        services.project_state.get().pcb_path()
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| "(none)".into())
     ));
     lines.push(format!(
         "  Gerber layers   = {}",
-        app.services.layer_store.layers.len()
+        services.layer_store.layers.len()
     ));
     lines.push(format!(
         "  BOM components  = {}",
-        app.bom_state.as_ref().map(|s| s.entries.len()).unwrap_or(0)
+        services.bom_component_count
     ));
     lines.push(format!(
         "  Units           = {}",
-        if app.services.global_units_mils { "mils" } else { "mm" }
+        if services.global_units_mils { "mils" } else { "mm" }
     ));
     lines.push(format!(
         "  KiCad           = {}",
-        app.services.kicad_version.as_deref().unwrap_or("(not detected)")
+        services.kicad_version.as_deref().unwrap_or("(not detected)")
     ));
     lines
 }

--- a/crates/copperforge-core/src/panels/shell.rs
+++ b/crates/copperforge-core/src/panels/shell.rs
@@ -97,21 +97,42 @@ fn execute_command(input: &str, services: &SharedServices) -> Vec<String> {
     match cmd.as_str() {
         "help" | "?" => vec![
             "Built-in commands:".into(),
-            "  help         Show this help".into(),
-            "  ver          Show CopperForge version".into(),
-            "  info         Show host OS / CPU / memory / network".into(),
-            "  status       Show current project + PCB + layers".into(),
-            "  env          Show discovered KiCad + relevant env vars".into(),
-            "  clear        Clear the shell".into(),
+            "  help              Show this help".into(),
+            "  ver               Show CopperForge version".into(),
+            "  info              Show host OS / CPU / memory / network".into(),
+            "  status            Show current project + PCB + layers".into(),
+            "  env               Show discovered KiCad + relevant env vars".into(),
+            "  new-project <n>   Scaffold a new KiCad project under the default".into(),
+            "                    projects directory using config defaults".into(),
+            "  clear             Clear the shell".into(),
             "".into(),
             "OS commands:".into(),
-            "  !<cmd>       Run an OS shell command (e.g. !uname -a)".into(),
-            "  sh <cmd>     Run an OS shell command (e.g. sh ls -la)".into(),
+            "  !<cmd>            Run an OS shell command (e.g. !uname -a)".into(),
+            "  sh <cmd>          Run an OS shell command (e.g. sh ls -la)".into(),
         ],
         "ver" | "version" => version_lines(),
         "info" | "system" | "sysinfo" => info_lines(),
         "status" | "state" => status_lines(services),
         "env" => env_lines(services),
+        "new-project" | "newproject" | "new" => {
+            if parts.len() < 2 {
+                vec![
+                    "Usage: new-project <name>".into(),
+                    "".into(),
+                    "Scaffolds <name>/ under ~/projects (or config-supplied dir)".into(),
+                    "with .kicad_pro / .kicad_sch / .kicad_pcb stubs, then adds".into(),
+                    "it to the CopperForge project DB.".into(),
+                    "".into(),
+                    "Defaults (from ~/.config/copperforge/project_config.json):".into(),
+                    format!("  author             = {}", services.config.default_author),
+                    format!("  company            = {}", services.config.default_company),
+                    format!("  include_kiverse    = {}", services.config.include_kiverse),
+                    format!("  include_atlantix   = {}", services.config.include_atlantix_resistors),
+                ]
+            } else {
+                new_project(parts[1], services)
+            }
+        }
         "sh" => {
             if parts.len() > 1 {
                 let shell_cmd = parts[1..].join(" ");
@@ -177,6 +198,80 @@ fn env_lines(services: &SharedServices) -> Vec<String> {
         lines.push(format!("  {var:<16} = {val}"));
     }
     lines
+}
+
+fn new_project(name: &str, services: &SharedServices) -> Vec<String> {
+    use crate::project_manager::kicad_project::{create_kicad_project, NewKicadProjectInfo};
+    use crate::project_manager::kicad_global_libs::setup_kiverse_globally;
+    use crate::project_manager::database::{generate_project_id, ProjectData, ProjectMetadata};
+
+    let name = name.trim().to_string();
+    if name.is_empty() {
+        return vec!["error: project name cannot be empty".into()];
+    }
+
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let location = services
+        .config
+        .preferred_projects_directory
+        .clone()
+        .unwrap_or_else(|| home.join("projects"));
+    let kiverse_path = home.join("kiverse");
+
+    // Optional: wire kiverse libs into the user's global KiCad config.
+    if services.config.include_kiverse || services.config.include_atlantix_resistors {
+        let kiverse_opt = if kiverse_path.exists() { Some(kiverse_path.clone()) } else { None };
+        if let Err(e) = setup_kiverse_globally(kiverse_opt) {
+            eprintln!("Warning: kiverse global setup failed: {}", e);
+        }
+    }
+
+    // Scaffold the .kicad_pro / .kicad_sch / .kicad_pcb on disk.
+    let mut info = NewKicadProjectInfo::new(name.clone(), location.clone());
+    info.author = services.config.default_author.clone();
+    info.company = services.config.default_company.clone();
+    info.include_kiverse = false;
+    info.include_atlantix_resistors = false;
+    info.kiverse_path = Some(kiverse_path);
+
+    let project_dir = match create_kicad_project(&info) {
+        Ok(dir) => dir,
+        Err(e) => return vec![format!("error: failed to create KiCad project: {}", e)],
+    };
+
+    // Register in the CopperForge DB.
+    let now = chrono::Utc::now();
+    let metadata = ProjectMetadata {
+        id: generate_project_id(),
+        name: name.clone(),
+        description: String::new(),
+        pcb_file_path: info.pcb_file_path(),
+        created_at: now,
+        last_modified: now,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        tags: Vec::new(),
+        parent_id: None,
+    };
+    let data = ProjectData {
+        metadata,
+        bom_components: Vec::new(),
+        notes: String::new(),
+        releases: Vec::new(),
+        hierarchy: None,
+    };
+    if let Err(e) = services.project_db.save_project(&data) {
+        return vec![
+            format!("warning: KiCad files created at {} but DB save failed: {}", project_dir.display(), e),
+        ];
+    }
+
+    vec![
+        format!("Created: {}", project_dir.display()),
+        format!("  .kicad_pro = {}", info.project_file_path().display()),
+        format!("  .kicad_sch = {}", info.schematic_file_path().display()),
+        format!("  .kicad_pcb = {}", info.pcb_file_path().display()),
+        "Registered in CopperForge project DB.".into(),
+    ]
 }
 
 fn status_lines(services: &SharedServices) -> Vec<String> {

--- a/crates/copperforge-core/src/panels/terminal.rs
+++ b/crates/copperforge-core/src/panels/terminal.rs
@@ -4,15 +4,19 @@ use egui::RichText;
 use egui_citizen::{Citizen, CitizenId, CitizenState};
 
 use super::citizen_panel;
+use crate::services::SharedServices;
 use crate::theme::TokyoNight;
 
 const PROMPT: &str = "$ ";
 const INPUT_ID: &str = "terminal_input";
 
-citizen_panel!(TerminalPanel, "terminal");
+citizen_panel!(TerminalPanel, "terminal",
+    output: Vec<String> = Vec::new(),
+    cmd_buf: String = String::new()
+);
 
 impl TerminalPanel {
-    pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
+    pub fn show(&mut self, ui: &mut egui::Ui, _services: &mut SharedServices) {
         let frame = egui::Frame::new()
             .fill(TokyoNight::BG_DARK)
             .inner_margin(8.0);
@@ -26,7 +30,7 @@ impl TerminalPanel {
                 .auto_shrink([false; 2])
                 .stick_to_bottom(true)
                 .show(ui, |ui| {
-                    for line in app.term_output.iter() {
+                    for line in self.output.iter() {
                         render_line(ui, line);
                     }
 
@@ -39,7 +43,7 @@ impl TerminalPanel {
                                 .strong(),
                         );
                         let response = ui.add(
-                            egui::TextEdit::singleline(&mut app.term_cmd_buf)
+                            egui::TextEdit::singleline(&mut self.cmd_buf)
                                 .id(text_id)
                                 .desired_width(ui.available_width())
                                 .font(egui::TextStyle::Monospace)
@@ -48,18 +52,18 @@ impl TerminalPanel {
                         );
 
                         if response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
-                            let input = app.term_cmd_buf.trim().to_string();
+                            let input = self.cmd_buf.trim().to_string();
                             if !input.is_empty() {
                                 if input == "clear" || input == "cls" {
-                                    app.term_output.clear();
+                                    self.output.clear();
                                 } else {
-                                    app.term_output.push(format!("{PROMPT}{input}"));
+                                    self.output.push(format!("{PROMPT}{input}"));
                                     for line in run_shell_command(&input) {
-                                        app.term_output.push(line);
+                                        self.output.push(line);
                                     }
                                 }
                             }
-                            app.term_cmd_buf.clear();
+                            self.cmd_buf.clear();
                             ui.memory_mut(|m| m.request_focus(text_id));
                         }
 

--- a/crates/copperforge-core/src/panels/view_settings.rs
+++ b/crates/copperforge-core/src/panels/view_settings.rs
@@ -5,6 +5,6 @@ citizen_panel!(ViewSettingsPanel, "view_settings");
 
 impl ViewSettingsPanel {
     pub fn show(&self, ui: &mut egui::Ui, app: &mut crate::CopperForgeApp) {
-        crate::ui::show_layers_panel(ui, app, &app.logger_state.clone(), &app.log_colors.clone());
+        crate::ui::show_layers_panel(ui, app, &app.services.logger_state.clone(), &app.services.log_colors.clone());
     }
 }

--- a/crates/copperforge-core/src/platform/details.rs
+++ b/crates/copperforge-core/src/platform/details.rs
@@ -1,5 +1,27 @@
 use sysinfo::System;
-use local_ip_address::local_ip;
+
+/// Discover a non-loopback IPv4 via `hostname -I` (Linux) / `ipconfig` (Windows) /
+/// `ifconfig` (macOS). Minimal shell-out replaces the `local-ip-address` crate.
+fn detect_local_ip() -> String {
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(out) = std::process::Command::new("hostname").arg("-I").output() {
+            if out.status.success() {
+                let s = String::from_utf8_lossy(&out.stdout);
+                if let Some(ip) = s.split_whitespace().next() {
+                    if !ip.is_empty() {
+                        return ip.to_string();
+                    }
+                }
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // Placeholder on non-Linux hosts; the IP line isn't critical.
+    }
+    "(not detected)".to_string()
+}
 
 #[derive(Default, Clone)]
 pub struct Details {
@@ -23,10 +45,7 @@ impl Details {
     }
 
     pub fn get_ip(&mut self) {
-        match local_ip() {
-            Ok(ip) => self.ip_addr = format!("{}", ip),
-            Err(err) => self.ip_addr = format!("Failed to get ip address {}", err),
-        };
+        self.ip_addr = detect_local_ip();
     }
 
     pub fn get_os(&mut self) {
@@ -38,10 +57,7 @@ impl Details {
         // First we update all information of our `System` struct.
         sys.refresh_all();
 
-        match local_ip() {
-            Ok(ip) => self.ip_addr = format!("{}", ip),
-            Err(err) => self.ip_addr = format!("Failed to get ip address {}", err),
-        };
+        self.ip_addr = detect_local_ip();
 
         // Detect the actual distro instead of using the generic system name
         // which usually just reports "Linux"

--- a/crates/copperforge-core/src/project/gerber_ops.rs
+++ b/crates/copperforge-core/src/project/gerber_ops.rs
@@ -69,13 +69,13 @@ pub fn generate_gerbers_from_pcb(
 /// Load gerber files from `gerber_dir` into the app's layer store.
 pub fn load_gerbers_into_viewer(app: &mut CopperForgeApp, gerber_dir: &Path, logger: &ReactiveEventLogger) {
     logger.log_info("Clearing existing gerber layers...");
-    app.layer_store.clear_all();
+    app.services.layer_store.clear_all();
 
-    match app.layer_store.load_from_directory(gerber_dir) {
+    match app.services.layer_store.load_from_directory(gerber_dir) {
         Ok((loaded_count, unassigned_count)) => {
             if loaded_count > 0 {
                 logger.log_info(&format!("Successfully loaded {} gerber layers", loaded_count));
-                app.needs_initial_view = true;
+                app.services.needs_initial_view = true;
             } else if unassigned_count > 0 {
                 logger.log_warning(&format!("{} gerber files could not be automatically assigned", unassigned_count));
             } else {

--- a/crates/copperforge-core/src/project_manager/database.rs
+++ b/crates/copperforge-core/src/project_manager/database.rs
@@ -4,7 +4,12 @@ use chrono::{DateTime, Utc};
 use crate::project_manager::bom::BomComponent;
 use crate::project_manager::kicad_hierarchy::ProjectHierarchy;
 
-/// Database manager for project storage
+/// Database manager for project storage.
+/// `Clone` is derived because `sled::Db` is internally Arc-backed — clones
+/// share the same underlying DB handle without re-acquiring the sled
+/// directory lock. This lets `ProjectManagerState` hold its own handle on
+/// the same DB that `SharedServices.project_db` opened at startup.
+#[derive(Clone)]
 pub struct ProjectDatabase {
     db: sled::Db,
 }
@@ -54,6 +59,10 @@ pub struct ProjectData {
     pub metadata: ProjectMetadata,
     pub bom_components: Vec<BomComponent>,
     pub notes: String,
+    /// Tagged fabrication releases (rev_01, rev_02, ...). Populated by the
+    /// Release workflow. `#[serde(default)]` keeps old DB records readable.
+    #[serde(default)]
+    pub releases: Vec<crate::release::Release>,
     /// Hierarchical structure of schematics and PCB files
     /// Cached for performance, can be regenerated from disk
     #[serde(skip)]
@@ -113,6 +122,7 @@ impl ProjectDatabase {
                                 },
                                 bom_components: old_project.bom_components,
                                 notes: old_project.notes,
+                                releases: Vec::new(),
                                 hierarchy: None, // Will be loaded on demand
                             };
 

--- a/crates/copperforge-core/src/project_manager/database.rs
+++ b/crates/copperforge-core/src/project_manager/database.rs
@@ -1,17 +1,32 @@
-use serde::{Serialize, Deserialize};
+//! Project database — embedded KV store backing the CopperForge project list.
+//!
+//! Switched from sled (~40 transitive crates) to redb (~5) for simpler,
+//! lighter storage. Behaviour preserved: one table keyed by
+//! `project:<id>` for full `ProjectData` records plus a single
+//! `index:projects` entry holding the ordered `Vec<String>` of project ids.
+
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
+use redb::{Database, TableDefinition};
+use serde::{Deserialize, Serialize};
+
 use crate::project_manager::bom::BomComponent;
 use crate::project_manager::kicad_hierarchy::ProjectHierarchy;
 
+const PROJECTS_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("projects");
+const INDEX_KEY: &str = "index:projects";
+
 /// Database manager for project storage.
-/// `Clone` is derived because `sled::Db` is internally Arc-backed — clones
-/// share the same underlying DB handle without re-acquiring the sled
-/// directory lock. This lets `ProjectManagerState` hold its own handle on
-/// the same DB that `SharedServices.project_db` opened at startup.
+///
+/// `Clone` shares the underlying redb handle via `Arc` — safe because
+/// redb serializes writes internally and supports concurrent reads.
+/// This is the reason multiple app-level components (SharedServices +
+/// ProjectManagerState) can each hold their own handle.
 #[derive(Clone)]
 pub struct ProjectDatabase {
-    db: sled::Db,
+    db: Arc<Database>,
 }
 
 /// Old project metadata format (before parent_id was added)
@@ -46,9 +61,8 @@ pub struct ProjectMetadata {
     pub last_modified: DateTime<Utc>,
     pub version: String,
     pub tags: Vec<String>,
-    /// Optional parent project ID for hierarchical organization
-    /// None means this is a root-level project
-    /// Default to None for backward compatibility with old database entries
+    /// Optional parent project ID for hierarchical organization.
+    /// None means this is a root-level project.
     #[serde(default)]
     pub parent_id: Option<String>,
 }
@@ -63,224 +77,226 @@ pub struct ProjectData {
     /// Release workflow. `#[serde(default)]` keeps old DB records readable.
     #[serde(default)]
     pub releases: Vec<crate::release::Release>,
-    /// Hierarchical structure of schematics and PCB files
-    /// Cached for performance, can be regenerated from disk
+    /// Hierarchical structure of schematics and PCB files.
+    /// Cached for performance, regenerable from disk.
     #[serde(skip)]
     pub hierarchy: Option<ProjectHierarchy>,
 }
 
 impl ProjectDatabase {
-    /// Create a new project database
+    /// Open (or create) the redb database at `db_path`. The parent directory
+    /// must exist. Initializes the `projects` table so reads on an empty DB
+    /// don't trip on "table not found".
     pub fn new(db_path: &Path) -> Result<Self, ProjectDatabaseError> {
-        let db = sled::open(db_path)
+        let db = Database::create(db_path)
             .map_err(|e| ProjectDatabaseError::DatabaseOpen(e.to_string()))?;
-        
-        Ok(Self { db })
+
+        // Touch the table on first open so subsequent reads don't error on
+        // a missing table definition.
+        let write_txn = db
+            .begin_write()
+            .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+        {
+            let _ = write_txn
+                .open_table(PROJECTS_TABLE)
+                .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+
+        Ok(Self { db: Arc::new(db) })
     }
 
-    /// Save a project to the database
+    /// Save a project (serialized via bincode) + update the ID index.
     pub fn save_project(&self, project: &ProjectData) -> Result<(), ProjectDatabaseError> {
         let key = format!("project:{}", project.metadata.id);
         let value = bincode::serialize(project)
             .map_err(|e| ProjectDatabaseError::Serialization(e.to_string()))?;
-        
-        self.db.insert(key.as_bytes(), value)
+
+        let write_txn = self.db.begin_write()
             .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
-        
-        // Update index for quick lookups
+        {
+            let mut table = write_txn.open_table(PROJECTS_TABLE)
+                .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+            table.insert(key.as_str(), value.as_slice())
+                .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+        }
+        write_txn.commit()
+            .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+
         self.update_project_index(&project.metadata)?;
-        
         Ok(())
     }
 
-    /// Load a project from the database
+    /// Load a project by ID, transparently migrating pre-parent_id records.
     pub fn load_project(&self, project_id: &str) -> Result<Option<ProjectData>, ProjectDatabaseError> {
         let key = format!("project:{}", project_id);
 
-        if let Some(value) = self.db.get(key.as_bytes())
-            .map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))? {
+        // Copy the bytes out of the read transaction so we can drop it before
+        // save_project() (which starts a write transaction) during migration.
+        let bytes: Option<Vec<u8>> = {
+            let read_txn = self.db.begin_read()
+                .map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))?;
+            let table = read_txn.open_table(PROJECTS_TABLE)
+                .map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))?;
+            match table.get(key.as_str()).map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))? {
+                Some(guard) => Some(guard.value().to_vec()),
+                None => None,
+            }
+        };
 
-            // Try to deserialize with current format
-            match bincode::deserialize::<ProjectData>(&value) {
-                Ok(project) => Ok(Some(project)),
-                Err(_) => {
-                    // Try to deserialize with old format (without parent_id)
-                    match bincode::deserialize::<OldProjectData>(&value) {
-                        Ok(old_project) => {
-                            // Migrate to new format
-                            let new_project = ProjectData {
-                                metadata: ProjectMetadata {
-                                    id: old_project.metadata.id,
-                                    name: old_project.metadata.name,
-                                    description: old_project.metadata.description,
-                                    pcb_file_path: old_project.metadata.pcb_file_path,
-                                    created_at: old_project.metadata.created_at,
-                                    last_modified: old_project.metadata.last_modified,
-                                    version: old_project.metadata.version,
-                                    tags: old_project.metadata.tags,
-                                    parent_id: None, // Default to root level
-                                },
-                                bom_components: old_project.bom_components,
-                                notes: old_project.notes,
-                                releases: Vec::new(),
-                                hierarchy: None, // Will be loaded on demand
-                            };
+        let bytes = match bytes {
+            Some(b) => b,
+            None => return Ok(None),
+        };
 
-                            // Save migrated project back to database
-                            self.save_project(&new_project)?;
-
-                            Ok(Some(new_project))
-                        }
-                        Err(e) => Err(ProjectDatabaseError::Deserialization(e.to_string()))
+        match bincode::deserialize::<ProjectData>(&bytes) {
+            Ok(project) => Ok(Some(project)),
+            Err(_) => {
+                // Try the pre-parent_id format and migrate.
+                match bincode::deserialize::<OldProjectData>(&bytes) {
+                    Ok(old) => {
+                        let migrated = ProjectData {
+                            metadata: ProjectMetadata {
+                                id: old.metadata.id,
+                                name: old.metadata.name,
+                                description: old.metadata.description,
+                                pcb_file_path: old.metadata.pcb_file_path,
+                                created_at: old.metadata.created_at,
+                                last_modified: old.metadata.last_modified,
+                                version: old.metadata.version,
+                                tags: old.metadata.tags,
+                                parent_id: None,
+                            },
+                            bom_components: old.bom_components,
+                            notes: old.notes,
+                            releases: Vec::new(),
+                            hierarchy: None,
+                        };
+                        self.save_project(&migrated)?;
+                        Ok(Some(migrated))
                     }
+                    Err(e) => Err(ProjectDatabaseError::Deserialization(e.to_string())),
                 }
             }
-        } else {
-            Ok(None)
         }
     }
 
-    /// List all projects (metadata only for performance)
+    /// List all project metadata (sorted by last_modified desc).
+    /// Reads the index, then loads each project for its metadata.
+    /// Skips corrupted / missing entries rather than failing the whole list.
     pub fn list_projects(&self) -> Result<Vec<ProjectMetadata>, ProjectDatabaseError> {
-        let mut projects = Vec::new();
+        let ids = self.read_index()?;
+        let mut projects = Vec::with_capacity(ids.len());
 
-        // Use index for efficient listing
-        if let Some(index_data) = self.db.get(b"index:projects")
-            .map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))? {
-
-            let project_ids: Vec<String> = bincode::deserialize(&index_data)
-                .map_err(|e| ProjectDatabaseError::Deserialization(e.to_string()))?;
-
-            for project_id in project_ids {
-                // Skip corrupted projects instead of failing completely
-                match self.load_project(&project_id) {
-                    Ok(Some(project)) => {
-                        // last_modified is the DB record's own timestamp, bumped by
-                        // update_project / update_project_bom. Do NOT overwrite it
-                        // with the PCB file's filesystem mtime — that conflated two
-                        // different things and made created_at appear later than
-                        // last_modified when the PCB file predated the DB record.
-                        projects.push(project.metadata);
-                    }
-                    Ok(None) => {
-                        eprintln!("Warning: Project {} not found in database", project_id);
-                    }
-                    Err(e) => {
-                        eprintln!("Warning: Failed to load project {}: {}. Skipping corrupted entry.", project_id, e);
-                    }
-                }
+        for project_id in ids {
+            match self.load_project(&project_id) {
+                Ok(Some(project)) => projects.push(project.metadata),
+                Ok(None) => eprintln!("Warning: Project {} not found in database", project_id),
+                Err(e) => eprintln!("Warning: Failed to load project {}: {}. Skipping.", project_id, e),
             }
         }
 
-        // Sort by last modified (newest first)
         projects.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
-
         Ok(projects)
     }
 
-    /// Delete a project
     pub fn delete_project(&self, project_id: &str) -> Result<(), ProjectDatabaseError> {
         let key = format!("project:{}", project_id);
-        
-        self.db.remove(key.as_bytes())
+
+        let write_txn = self.db.begin_write()
             .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
-        
-        // Remove from index
+        {
+            let mut table = write_txn.open_table(PROJECTS_TABLE)
+                .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+            table.remove(key.as_str())
+                .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+        }
+        write_txn.commit()
+            .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+
         self.remove_from_project_index(project_id)?;
-        
         Ok(())
     }
 
-    /// Search projects by name or description
     pub fn search_projects(&self, query: &str) -> Result<Vec<ProjectMetadata>, ProjectDatabaseError> {
         let all_projects = self.list_projects()?;
-        let query_lower = query.to_lowercase();
-        
-        let filtered: Vec<ProjectMetadata> = all_projects
+        let q = query.to_lowercase();
+        Ok(all_projects
             .into_iter()
-            .filter(|project| {
-                project.name.to_lowercase().contains(&query_lower) ||
-                project.description.to_lowercase().contains(&query_lower) ||
-                project.tags.iter().any(|tag| tag.to_lowercase().contains(&query_lower))
+            .filter(|p| {
+                p.name.to_lowercase().contains(&q)
+                    || p.description.to_lowercase().contains(&q)
+                    || p.tags.iter().any(|t| t.to_lowercase().contains(&q))
             })
-            .collect();
-        
-        Ok(filtered)
+            .collect())
     }
 
-    /// Find project by PCB file path
-    pub fn find_project_by_pcb_path(&self, pcb_path: &std::path::Path) -> Result<Option<ProjectData>, ProjectDatabaseError> {
-        let all_projects = self.list_projects()?;
-        
-        for project_metadata in all_projects {
-            if project_metadata.pcb_file_path == pcb_path {
-                if let Some(project_data) = self.load_project(&project_metadata.id)? {
-                    return Ok(Some(project_data));
+    pub fn find_project_by_pcb_path(&self, pcb_path: &Path) -> Result<Option<ProjectData>, ProjectDatabaseError> {
+        for meta in self.list_projects()? {
+            if meta.pcb_file_path == pcb_path {
+                if let Some(data) = self.load_project(&meta.id)? {
+                    return Ok(Some(data));
                 }
             }
         }
-        
         Ok(None)
     }
 
-    /// Update project index for quick listings
-    fn update_project_index(&self, metadata: &ProjectMetadata) -> Result<(), ProjectDatabaseError> {
-        let mut project_ids: Vec<String> = if let Some(index_data) = self.db.get(b"index:projects")
-            .map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))? {
-            
-            bincode::deserialize(&index_data)
-                .map_err(|e| ProjectDatabaseError::Deserialization(e.to_string()))?
-        } else {
-            Vec::new()
-        };
-        
-        // Add project ID if not already present
-        if !project_ids.contains(&metadata.id) {
-            project_ids.push(metadata.id.clone());
-        }
-        
-        let index_data = bincode::serialize(&project_ids)
-            .map_err(|e| ProjectDatabaseError::Serialization(e.to_string()))?;
-        
-        self.db.insert(b"index:projects", index_data)
-            .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
-        
-        Ok(())
-    }
-
-    /// Remove project from index
-    fn remove_from_project_index(&self, project_id: &str) -> Result<(), ProjectDatabaseError> {
-        if let Some(index_data) = self.db.get(b"index:projects")
-            .map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))? {
-            
-            let mut project_ids: Vec<String> = bincode::deserialize(&index_data)
-                .map_err(|e| ProjectDatabaseError::Deserialization(e.to_string()))?;
-            
-            project_ids.retain(|id| id != project_id);
-            
-            let index_data = bincode::serialize(&project_ids)
-                .map_err(|e| ProjectDatabaseError::Serialization(e.to_string()))?;
-            
-            self.db.insert(b"index:projects", index_data)
-                .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
-        }
-        
-        Ok(())
-    }
-
-    /// Get database statistics
     pub fn get_stats(&self) -> Result<DatabaseStats, ProjectDatabaseError> {
         let projects = self.list_projects()?;
-        let total_projects = projects.len();
-        
-        let size_on_disk = self.db.size_on_disk()
-            .map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))?;
-        
         Ok(DatabaseStats {
-            total_projects,
-            size_on_disk,
+            total_projects: projects.len(),
+            // redb doesn't expose an exact on-disk size cheaply; report 0
+            // (this field isn't surfaced in the UI today anyway).
+            size_on_disk: 0,
             last_accessed: Utc::now(),
         })
+    }
+
+    // ── internals ────────────────────────────────────────────────────
+
+    fn read_index(&self) -> Result<Vec<String>, ProjectDatabaseError> {
+        let read_txn = self.db.begin_read()
+            .map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))?;
+        let table = read_txn.open_table(PROJECTS_TABLE)
+            .map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))?;
+        match table.get(INDEX_KEY).map_err(|e| ProjectDatabaseError::DatabaseRead(e.to_string()))? {
+            Some(guard) => bincode::deserialize(guard.value())
+                .map_err(|e| ProjectDatabaseError::Deserialization(e.to_string())),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    fn write_index(&self, ids: &[String]) -> Result<(), ProjectDatabaseError> {
+        let bytes = bincode::serialize(ids)
+            .map_err(|e| ProjectDatabaseError::Serialization(e.to_string()))?;
+        let write_txn = self.db.begin_write()
+            .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+        {
+            let mut table = write_txn.open_table(PROJECTS_TABLE)
+                .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+            table.insert(INDEX_KEY, bytes.as_slice())
+                .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+        }
+        write_txn.commit()
+            .map_err(|e| ProjectDatabaseError::DatabaseWrite(e.to_string()))?;
+        Ok(())
+    }
+
+    fn update_project_index(&self, metadata: &ProjectMetadata) -> Result<(), ProjectDatabaseError> {
+        let mut ids = self.read_index()?;
+        if !ids.contains(&metadata.id) {
+            ids.push(metadata.id.clone());
+        }
+        self.write_index(&ids)
+    }
+
+    fn remove_from_project_index(&self, project_id: &str) -> Result<(), ProjectDatabaseError> {
+        let mut ids = self.read_index()?;
+        ids.retain(|id| id != project_id);
+        self.write_index(&ids)
     }
 }
 
@@ -297,16 +313,16 @@ pub struct DatabaseStats {
 pub enum ProjectDatabaseError {
     #[error("Failed to open database: {0}")]
     DatabaseOpen(String),
-    
+
     #[error("Failed to read from database: {0}")]
     DatabaseRead(String),
-    
+
     #[error("Failed to write to database: {0}")]
     DatabaseWrite(String),
-    
+
     #[error("Failed to serialize data: {0}")]
     Serialization(String),
-    
+
     #[error("Failed to deserialize data: {0}")]
     Deserialization(String),
 }
@@ -318,23 +334,20 @@ pub fn generate_project_id() -> String {
         .duration_since(UNIX_EPOCH)
         .unwrap()
         .as_millis();
-
     format!("proj_{}", timestamp)
 }
 
 impl ProjectData {
-    /// Load the project hierarchy from the KiCad project file
-    /// This parses the .kicad_pro file and associated schematics
+    /// Load the project hierarchy from the KiCad project file.
+    /// Parses the .kicad_pro file and associated schematics.
     pub fn load_hierarchy(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         use crate::project_manager::kicad_metadata::get_kicad_pro_path;
 
-        // Get the .kicad_pro path from the PCB path
         if let Some(kicad_pro_path) = get_kicad_pro_path(&self.metadata.pcb_file_path) {
             if kicad_pro_path.exists() {
                 self.hierarchy = Some(ProjectHierarchy::from_kicad_pro(&kicad_pro_path)?);
             }
         }
-
         Ok(())
     }
 }

--- a/crates/copperforge-core/src/project_manager/mod.rs
+++ b/crates/copperforge-core/src/project_manager/mod.rs
@@ -7,11 +7,13 @@ pub mod kicad_hierarchy;
 
 use database::{ProjectDatabase, ProjectData, ProjectMetadata, generate_project_id, ProjectDatabaseError};
 use bom::BomComponent;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use chrono::Utc;
 use egui_file_dialog::FileDialog;
 
-/// Project manager state
+/// Project manager state. Create-new-project scaffolding was moved to the
+/// Shell panel's `new-project` command; what's left here is strictly the
+/// import / list / edit / delete flow for the CopperForge project DB.
 pub struct ProjectManagerState {
     pub database: Option<ProjectDatabase>,
     pub current_project: Option<ProjectData>,
@@ -26,24 +28,23 @@ pub struct ProjectManagerState {
     pub new_project_pcb_path: Option<PathBuf>,
     pub new_project_parent_id: Option<String>,
     pub last_error: Option<String>,
-    // New fields for creating KiCad projects from scratch
-    pub create_new_kicad_project: bool,
-    pub new_kicad_project_location: PathBuf,
-    pub new_kicad_project_author: String,
-    pub new_kicad_project_company: String,
-    pub include_kiverse: bool,
-    pub include_atlantix_resistors: bool,
-    pub kiverse_path: PathBuf,
-    // File dialogs
+    /// File dialog for picking a .kicad_pro to import.
     pub pcb_file_dialog: FileDialog,
-    pub location_dialog: FileDialog,
-    // Recent project names (for quick iteration)
+    /// Recent project names (for quick form re-fill).
     pub recent_project_names: Vec<String>,
-    // Track last picked file to avoid re-processing
+    /// Last .kicad_pro path processed — gates the pedigree auto-fill so we
+    /// don't re-run it every frame while the dialog reports the same pick.
+    /// Cleared on `reset_create_dialog` so re-picking after a successful
+    /// import actually re-populates the form.
     pub last_picked_pro_path: Option<PathBuf>,
-    // Project hierarchy tree view
+    /// Project hierarchy tree view
     pub expanded_project_id: Option<String>,
     pub project_hierarchies: std::collections::HashMap<String, kicad_hierarchy::ProjectHierarchy>,
+    /// Per-project release cache, keyed by project id. Rebuilt on
+    /// `initialize_database()` and bumped by `record_release()` when a
+    /// new release is cut via the Release modal. Drives the `outputs/`
+    /// subtree in the Projects tab.
+    pub project_releases: std::collections::HashMap<String, Vec<crate::release::Release>>,
 }
 
 impl Default for ProjectManagerState {
@@ -53,10 +54,10 @@ impl Default for ProjectManagerState {
 }
 
 impl ProjectManagerState {
-    /// Create a new ProjectManagerState with values from ProjectConfig
-    pub fn with_config(config: &crate::project::manager::ProjectConfig) -> Self {
-        let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-
+    /// Create a new ProjectManagerState. Most fields default to empty /
+    /// None and get populated as the user interacts with the import form.
+    /// `_config` is kept for signature stability (callers pass it today).
+    pub fn with_config(_config: &crate::project::manager::ProjectConfig) -> Self {
         Self {
             database: None,
             current_project: None,
@@ -71,32 +72,52 @@ impl ProjectManagerState {
             new_project_pcb_path: None,
             new_project_parent_id: None,
             last_error: None,
-            create_new_kicad_project: true,  // Default to creating new projects
-            new_kicad_project_location: home_dir.clone(),
-            new_kicad_project_author: config.default_author.clone(),
-            new_kicad_project_company: config.default_company.clone(),
-            include_kiverse: config.include_kiverse,
-            include_atlantix_resistors: config.include_atlantix_resistors,
-            kiverse_path: home_dir.join("kiverse"),
             pcb_file_dialog: FileDialog::new(),
-            location_dialog: FileDialog::new(),
             recent_project_names: Vec::new(),
             last_picked_pro_path: None,
             expanded_project_id: None,
             project_hierarchies: std::collections::HashMap::new(),
+            project_releases: std::collections::HashMap::new(),
         }
     }
 
-    /// Initialize the project database
-    pub fn initialize_database(&mut self, db_path: &Path) -> Result<(), ProjectDatabaseError> {
-        let database = ProjectDatabase::new(db_path)?;
-        self.project_list = database.list_projects()?;
-        self.database = Some(database);
-
-        // Populate recent project names (5 most recent)
+    /// Wire up the project database by cloning the shared handle.
+    /// `ProjectDatabase` is `Clone` — the sled handle underneath is Arc-backed,
+    /// so this does NOT re-acquire the directory lock. The bug was that the
+    /// previous implementation called `ProjectDatabase::new(db_path)` here
+    /// while `SharedServices` had already opened the same path at startup;
+    /// sled's exclusive lock made the second open silently fail, leaving
+    /// `self.database = None` and every subsequent DB call erroring with
+    /// "Database not initialized."
+    pub fn initialize_database(&mut self, db: &ProjectDatabase) -> Result<(), ProjectDatabaseError> {
+        self.project_list = db.list_projects()?;
+        self.database = Some(db.clone());
         self.update_recent_project_names();
-
+        self.reload_all_releases(db);
         Ok(())
+    }
+
+    /// Rebuild the per-project release cache from the DB.
+    /// O(N) full-project loads; fine at the scale we expect (dozens of
+    /// projects at most). Silently skips any project that fails to load.
+    pub fn reload_all_releases(&mut self, db: &ProjectDatabase) {
+        self.project_releases.clear();
+        for meta in &self.project_list {
+            if let Ok(Some(data)) = db.load_project(&meta.id) {
+                if !data.releases.is_empty() {
+                    self.project_releases.insert(meta.id.clone(), data.releases);
+                }
+            }
+        }
+    }
+
+    /// Record a freshly-created release in both the live cache and the DB's
+    /// current_project snapshot. Called from the Release modal dispatcher.
+    pub fn record_release(&mut self, project_id: &str, release: crate::release::Release) {
+        self.project_releases
+            .entry(project_id.to_string())
+            .or_default()
+            .push(release);
     }
 
     /// Update recent project names list with the 5 most recently modified projects
@@ -129,6 +150,14 @@ impl ProjectManagerState {
         bom_components: Vec<BomComponent>,
     ) -> Result<String, ProjectDatabaseError> {
         if let Some(ref database) = self.database {
+            // Dedup: the same .kicad_pcb can only back one DB record.
+            if let Some(existing) = database.find_project_by_pcb_path(&pcb_file_path)? {
+                return Err(ProjectDatabaseError::DatabaseWrite(format!(
+                    "Project '{}' is already imported (ID: {}). Open it from the Projects tab instead.",
+                    existing.metadata.name, existing.metadata.id
+                )));
+            }
+
             let project_id = generate_project_id();
             let now = Utc::now();
 
@@ -148,6 +177,7 @@ impl ProjectManagerState {
                 metadata: metadata.clone(),
                 bom_components,
                 notes: String::new(),
+                releases: Vec::new(),
                 hierarchy: None, // Will be loaded on demand
             };
             
@@ -260,84 +290,11 @@ impl ProjectManagerState {
         }
     }
 
-    /// Create a new KiCad project from scratch
-    pub fn create_new_kicad_project_from_scratch(
-        &mut self,
-        name: String,
-        description: String,
-        tags: Vec<String>,
-    ) -> Result<String, ProjectDatabaseError> {
-        use kicad_project::{NewKicadProjectInfo, create_kicad_project};
-        use kicad_global_libs::setup_kiverse_globally;
-
-        // Setup KiVerse in global KiCad configuration if requested
-        if self.include_kiverse || self.include_atlantix_resistors {
-            let kiverse_path_option = if self.kiverse_path.exists() {
-                Some(self.kiverse_path.clone())
-            } else {
-                None
-            };
-
-            // Try to setup global libraries, but don't fail if it doesn't work
-            if let Err(e) = setup_kiverse_globally(kiverse_path_option) {
-                eprintln!("Warning: Failed to setup KiVerse globally: {}", e);
-                // Continue anyway - the project will still be created
-            }
-        }
-
-        // Create project info
-        let mut project_info = NewKicadProjectInfo::new(name.clone(), self.new_kicad_project_location.clone());
-        project_info.author = self.new_kicad_project_author.clone();
-        project_info.description = description.clone();
-        project_info.company = self.new_kicad_project_company.clone();
-        project_info.include_kiverse = false;  // Don't create local library tables
-        project_info.include_atlantix_resistors = false;  // Don't create local library tables
-        project_info.kiverse_path = Some(self.kiverse_path.clone());
-
-        // Create the KiCad project files
-        let _project_dir = create_kicad_project(&project_info)
-            .map_err(|e| ProjectDatabaseError::DatabaseWrite(format!("Failed to create KiCad project: {}", e)))?;
-
-        // Now add to our project database
-        let pcb_file_path = project_info.pcb_file_path();
-
-        if let Some(ref database) = self.database {
-            let project_id = generate_project_id();
-            let now = Utc::now();
-
-            let metadata = ProjectMetadata {
-                id: project_id.clone(),
-                name,
-                description,
-                pcb_file_path,
-                created_at: now,
-                last_modified: now,
-                version: env!("CARGO_PKG_VERSION").to_string(),
-                tags,
-                parent_id: self.new_project_parent_id.clone(),
-            };
-
-            let project_data = ProjectData {
-                metadata: metadata.clone(),
-                bom_components: Vec::new(),
-                notes: String::new(),
-                hierarchy: None, // Will be loaded on demand
-            };
-
-            database.save_project(&project_data)?;
-            self.project_list = database.list_projects()?;
-            self.current_project = Some(project_data);
-
-            // Update recent project names
-            self.update_recent_project_names();
-
-            Ok(project_id)
-        } else {
-            Err(ProjectDatabaseError::DatabaseRead("Database not initialized".to_string()))
-        }
-    }
-
-    /// Reset create dialog (clears project-specific fields only, keeps user preferences)
+    /// Reset the import form. Clears transient form state AND
+    /// `last_picked_pro_path` — without the latter, re-picking the same
+    /// .kicad_pro after a successful import would be skipped by the
+    /// "already processed" guard, leaving the form empty and producing
+    /// the "Project name cannot be empty" error.
     pub fn reset_create_dialog(&mut self) {
         self.show_create_dialog = false;
         self.new_project_name.clear();
@@ -345,14 +302,12 @@ impl ProjectManagerState {
         self.new_project_tags.clear();
         self.new_project_pcb_path = None;
         self.new_project_parent_id = None;
-        // Note: We keep author, company, location, and library preferences
-        // so the user doesn't have to re-enter them each time
+        self.last_picked_pro_path = None;
     }
 
-    /// Reset all fields including user preferences (for cancel action)
+    /// Reset all fields (parity wrapper for call sites that distinguished
+    /// between "cancel" and "reset"; behaviour is identical now).
     pub fn cancel_create_dialog(&mut self) {
         self.reset_create_dialog();
-        // Could optionally clear user fields here if desired
-        // For now, we keep them to save typing
     }
 }

--- a/crates/copperforge-core/src/release/mod.rs
+++ b/crates/copperforge-core/src/release/mod.rs
@@ -1,39 +1,317 @@
 //! Release management — tag and track gerber fabrication releases.
 //!
-//! Each release is a snapshot of gerber/drill files for a specific
-//! fabrication run, e.g. "pcbway_01June2025_release".
-//!
-//! Future: ReleaseManager will handle creating tagged releases,
-//! archiving gerber sets, and tracking fabrication history.
+//! A release is a point-in-time snapshot of everything needed to send the
+//! PCB out for fabrication: gerbers, drill files, and an optional
+//! RELEASE_NOTES.md, bundled into a single `.zip` under
+//! `<project_dir>/outputs/<rev_name>/`.
 
-use std::path::PathBuf;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 
-/// A tagged fabrication release.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+use chrono::{DateTime, Local, Utc};
+use serde::{Deserialize, Serialize};
+use zip::write::SimpleFileOptions;
+use zip::ZipWriter;
+
+use crate::event_logger::ReactiveEventLogger;
+
+/// A tagged fabrication release. Persisted under `ProjectData.releases`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Release {
-    /// Human-readable tag, e.g. "pcbway_01June2025_release"
+    /// User-chosen rev tag, e.g. "rev_01" or "rev_01a".
     pub tag: String,
-    /// When the release was created
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    /// Path to the archived gerber/drill package
+    /// When the release was created.
+    pub created_at: DateTime<Utc>,
+    /// Path to the archived gerber/drill package (`<project>/outputs/<tag>/<name>.zip`).
     pub archive_path: PathBuf,
-    /// Which vendor this release targets (if any)
-    pub vendor: Option<String>,
-    /// Notes about this release
-    pub notes: String,
+    /// Path to the RELEASE_NOTES.md file (always created next to the zip).
+    pub notes_path: PathBuf,
+    /// Short "what this board is about" description (from the modal).
+    pub description: String,
+    /// User-provided changes-from-previous-version text (markdown).
+    pub changes: String,
+    /// Detected KiCad version at release time.
+    pub kicad_version: Option<String>,
+    /// Git commit hash at release time, if the project dir is inside a repo.
+    pub git_hash: Option<String>,
+    /// Whether the zip filename includes the date (e.g. `_18Apr2026`).
+    pub include_date_in_name: bool,
+    /// Whether RELEASE_NOTES.md was bundled into the zip.
+    pub include_notes_in_zip: bool,
 }
 
-/// Manages fabrication releases for a project.
-#[derive(Default)]
-pub struct ReleaseManager {
-    pub releases: Vec<Release>,
+/// Input collected from the Release modal.
+pub struct ReleaseRequest {
+    pub rev_tag: String,
+    pub description: String,
+    pub changes: String,
+    pub include_date_in_name: bool,
+    pub include_notes_in_zip: bool,
 }
 
-impl ReleaseManager {
-    pub fn new() -> Self { Self::default() }
+/// Where source artifacts are found; supplied by the caller after a normal
+/// Generate+Load has produced gerbers.
+pub struct ReleaseSources<'a> {
+    pub pcb_path: &'a Path,
+    pub gerber_dir: &'a Path,
+    pub kicad_cli: std::process::Command,
+    pub kicad_version: Option<String>,
+    pub os_description: String,
+}
 
-    // TODO: create_release(tag, gerber_dir, vendor) -> Result<Release>
-    // TODO: list_releases() -> &[Release]
-    // TODO: load_from_project(project_path) -> Self
-    // TODO: save_to_project(project_path) -> Result<()>
+/// Result of a create-release operation.
+pub struct ReleaseOutcome {
+    pub release: Release,
+}
+
+/// Create a release on disk: `<project_dir>/outputs/<rev_tag>/` containing
+/// - `<project>_<rev>[_<DDMMMYYYY>].zip` (gerbers + drill [+ notes if opted in])
+/// - `RELEASE_NOTES.md` (always written next to the zip)
+///
+/// Returns the `Release` metadata; the caller is responsible for appending
+/// it to the project's DB record.
+pub fn create_release(
+    req: &ReleaseRequest,
+    sources: ReleaseSources<'_>,
+    logger: &ReactiveEventLogger,
+) -> Result<ReleaseOutcome, String> {
+    let project_dir = sources
+        .pcb_path
+        .parent()
+        .ok_or_else(|| "PCB path has no parent directory".to_string())?;
+
+    let project_stem = sources
+        .pcb_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("project");
+
+    let outputs_root = project_dir.join("outputs");
+    let rev_dir = outputs_root.join(&req.rev_tag);
+    std::fs::create_dir_all(&rev_dir)
+        .map_err(|e| format!("Failed to create release dir {}: {}", rev_dir.display(), e))?;
+
+    logger.log_info(&format!("Release dir: {}", rev_dir.display()));
+
+    // 1. Export drill files (gerbers are already in sources.gerber_dir).
+    let drill_dir = rev_dir.join("drill_staging");
+    std::fs::create_dir_all(&drill_dir)
+        .map_err(|e| format!("Failed to create drill staging dir: {}", e))?;
+    export_drill(sources.kicad_cli, sources.pcb_path, &drill_dir, logger)?;
+
+    // 2. Resolve git commit (optional).
+    let git_hash = git_head_short(project_dir);
+    if let Some(ref h) = git_hash {
+        logger.log_info(&format!("Git commit: {}", h));
+    }
+
+    let now_utc = Utc::now();
+    let now_local = Local::now();
+    let date_stamp = now_local.format("%d%b%Y").to_string();
+
+    // 3. Zip filename.
+    let zip_name = if req.include_date_in_name {
+        format!("{}_{}_{}.zip", project_stem, req.rev_tag, date_stamp)
+    } else {
+        format!("{}_{}.zip", project_stem, req.rev_tag)
+    };
+    let zip_path = rev_dir.join(&zip_name);
+
+    // 4. Write RELEASE_NOTES.md next to the zip.
+    let notes_path = rev_dir.join("RELEASE_NOTES.md");
+    let notes_markdown = build_release_notes(
+        project_stem,
+        &req.rev_tag,
+        &req.description,
+        &req.changes,
+        &now_local.format("%Y-%m-%d %H:%M:%S %Z").to_string(),
+        sources.kicad_version.as_deref(),
+        &sources.os_description,
+        git_hash.as_deref(),
+    );
+    std::fs::write(&notes_path, &notes_markdown)
+        .map_err(|e| format!("Failed to write RELEASE_NOTES.md: {}", e))?;
+
+    // 5. Build the archive.
+    let notes_for_zip = if req.include_notes_in_zip {
+        Some((notes_path.as_path(), "RELEASE_NOTES.md"))
+    } else {
+        None
+    };
+    write_release_zip(&zip_path, sources.gerber_dir, &drill_dir, notes_for_zip)
+        .map_err(|e| format!("Failed to build zip: {}", e))?;
+
+    // 6. Clean up drill staging (its contents are in the zip now).
+    let _ = std::fs::remove_dir_all(&drill_dir);
+
+    logger.log_info(&format!("Release archive: {}", zip_path.display()));
+
+    let release = Release {
+        tag: req.rev_tag.clone(),
+        created_at: now_utc,
+        archive_path: zip_path,
+        notes_path,
+        description: req.description.clone(),
+        changes: req.changes.clone(),
+        kicad_version: sources.kicad_version,
+        git_hash,
+        include_date_in_name: req.include_date_in_name,
+        include_notes_in_zip: req.include_notes_in_zip,
+    };
+
+    Ok(ReleaseOutcome { release })
+}
+
+/// Suggest the next rev tag based on the project's existing releases.
+/// e.g. ["rev_01"] → "rev_02"; [] → "rev_01"; anything unrecognized → "rev_01".
+pub fn suggest_next_rev_tag(existing: &[Release]) -> String {
+    let mut highest: u32 = 0;
+    for r in existing {
+        if let Some(num_str) = r.tag.strip_prefix("rev_") {
+            // Take leading digits only, tolerate suffixes like "_01a".
+            let digits: String = num_str.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if let Ok(n) = digits.parse::<u32>() {
+                highest = highest.max(n);
+            }
+        }
+    }
+    format!("rev_{:02}", highest + 1)
+}
+
+// ── internals ────────────────────────────────────────────────────────────
+
+fn export_drill(
+    mut cmd: std::process::Command,
+    pcb_path: &Path,
+    drill_dir: &Path,
+    logger: &ReactiveEventLogger,
+) -> Result<(), String> {
+    let output = cmd
+        .arg("pcb")
+        .arg("export")
+        .arg("drill")
+        .arg("--output")
+        .arg(drill_dir)
+        .arg(pcb_path)
+        .output()
+        .map_err(|e| format!("kicad-cli drill export failed to spawn: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("kicad-cli drill export failed: {}", stderr.trim()));
+    }
+    let listed: Vec<_> = std::fs::read_dir(drill_dir)
+        .map_err(|e| format!("Failed to read drill dir: {}", e))?
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    logger.log_info(&format!("Drill files: {}", listed.join(", ")));
+    Ok(())
+}
+
+fn git_head_short(project_dir: &Path) -> Option<String> {
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(project_dir)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_release_notes(
+    project: &str,
+    rev_tag: &str,
+    description: &str,
+    changes: &str,
+    when: &str,
+    kicad_version: Option<&str>,
+    os_description: &str,
+    git_hash: Option<&str>,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# {} — {}\n\n", project, rev_tag));
+    out.push_str(&format!("**Released:** {}\n\n", when));
+    out.push_str(&format!(
+        "**KiCad version:** {}\n\n",
+        kicad_version.unwrap_or("(not detected)")
+    ));
+    out.push_str(&format!("**Host OS:** {}\n\n", os_description));
+    out.push_str(&format!(
+        "**Git commit:** {}\n\n",
+        git_hash.unwrap_or("(not in a git repository)")
+    ));
+    out.push_str("## Description\n\n");
+    if description.trim().is_empty() {
+        out.push_str("_(none provided)_\n\n");
+    } else {
+        out.push_str(description.trim());
+        out.push_str("\n\n");
+    }
+    out.push_str("## Changes from previous version\n\n");
+    if changes.trim().is_empty() {
+        out.push_str("_(none provided)_\n\n");
+    } else {
+        out.push_str(changes.trim());
+        out.push_str("\n\n");
+    }
+    out
+}
+
+fn write_release_zip(
+    zip_path: &Path,
+    gerber_dir: &Path,
+    drill_dir: &Path,
+    notes: Option<(&Path, &str)>,
+) -> std::io::Result<()> {
+    let file = File::create(zip_path)?;
+    let mut zw = ZipWriter::new(file);
+    let opts: SimpleFileOptions = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    // Gerbers
+    for entry in std::fs::read_dir(gerber_dir)? {
+        let path = entry?.path();
+        if path.is_file() {
+            add_to_zip(&mut zw, &path, None, opts)?;
+        }
+    }
+
+    // Drills
+    for entry in std::fs::read_dir(drill_dir)? {
+        let path = entry?.path();
+        if path.is_file() {
+            add_to_zip(&mut zw, &path, None, opts)?;
+        }
+    }
+
+    // Notes
+    if let Some((notes_path, name_in_zip)) = notes {
+        add_to_zip(&mut zw, notes_path, Some(name_in_zip), opts)?;
+    }
+
+    zw.finish()?;
+    Ok(())
+}
+
+fn add_to_zip(
+    zw: &mut ZipWriter<File>,
+    src: &Path,
+    alias: Option<&str>,
+    opts: SimpleFileOptions,
+) -> std::io::Result<()> {
+    let name = alias
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| src.file_name().unwrap().to_string_lossy().into_owned());
+    zw.start_file(name, opts)?;
+    let mut f = File::open(src)?;
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf)?;
+    zw.write_all(&buf)?;
+    Ok(())
 }

--- a/crates/copperforge-core/src/services.rs
+++ b/crates/copperforge-core/src/services.rs
@@ -1,8 +1,10 @@
-//! Shared domain services accessible by all citizen panels.
+//! Shared application services — the single source of truth for state that
+//! crosses panel boundaries.
 //!
-//! This struct will replace the flat fields on `CopperForgeApp` once the
-//! migration to citizen panels is complete. Panels receive `&SharedServices`
-//! (read) or `&mut SharedServices` (write) instead of `&mut CopperForgeApp`.
+//! Populated eagerly during `CopperForgeApp::new()` via an explicit init
+//! sequence (config → KiCad discovery → project DB). Panels read and mutate
+//! `SharedServices` directly; panel-local state lives inside the panel's
+//! citizen struct.
 
 use std::path::PathBuf;
 
@@ -12,38 +14,47 @@ use gerber_viewer::{GerberLayer, ViewState, UiState};
 
 use crate::display::{DisplayManager, GridSettings};
 use crate::drc_operations::DrcManager;
-use crate::event_logger::{ReactiveEventLoggerState, LogColors};
-use crate::project::ProjectManager;
+use crate::event_logger::{LogColors, ReactiveEventLoggerState};
+use crate::project::{manager::ProjectConfig, ProjectState};
+use crate::project_manager::database::ProjectDatabase;
 
-/// Shared domain state accessible by all citizen panels.
+/// Every cross-panel fact lives here. Populated once at init.
 pub struct SharedServices {
-    // ── Logger (reactive, cloneable) ──────────────────────────
+    // ── Reactive (observable across panels) ───────────────────
+    /// Drives BOM refresh, gerber ribbon state, and everything else that
+    /// keys off "which PCB is active and what stage are we at".
+    pub project_state: Dynamic<ProjectState>,
     pub logger_state: Dynamic<ReactiveEventLoggerState>,
     pub log_colors: Dynamic<LogColors>,
 
+    // ── Init-time facts (set once, rarely mutate) ─────────────
+    pub config: ProjectConfig,
+    pub config_path: PathBuf,
+    pub kicad_version: Option<String>,
+    /// One of "path" / "flatpak" / "snap". Used by
+    /// `CopperForgeApp::kicad_cli_command()` to build Commands without probing.
+    pub kicad_cli_method: Option<String>,
+    pub project_db: ProjectDatabase,
+
     // ── Gerber / viewport ─────────────────────────────────────
+    pub layer_store: crate::layer_store::LayerStore,
     pub gerber_layer: GerberLayer,
     pub view_state: ViewState,
     pub ui_state: UiState,
     pub needs_initial_view: bool,
     pub rotation_degrees: f32,
 
-    // ── Display ───────────────────────────────────────────────
+    // ── Display / DRC / grid ──────────────────────────────────
     pub display_manager: DisplayManager,
+    pub drc_manager: DrcManager,
     pub grid_settings: GridSettings,
     pub global_units_mils: bool,
 
-    // ── Domain managers ───────────────────────────────────────
-    pub drc_manager: DrcManager,
-    pub project_manager: ProjectManager,
+    // ── User preferences ──────────────────────────────────────
+    pub user_timezone: Option<String>,
+    pub use_24_hour_clock: bool,
 
-    // ── Layer management ────────────────────────────────────
-    pub layer_store: crate::layer_store::LayerStore,
-
-    // ── Config persistence ────────────────────────────────────
-    pub config_path: PathBuf,
-
-    // ── Viewport interaction state ────────────────────────────
+    // ── Viewport interaction ──────────────────────────────────
     pub zoom_window_start: Option<Pos2>,
     pub zoom_window_dragging: bool,
     pub setting_origin_mode: bool,
@@ -58,12 +69,7 @@ pub struct SharedServices {
     pub latched_measurement_start: Option<nalgebra::Point2<f64>>,
     pub latched_measurement_end: Option<nalgebra::Point2<f64>>,
 
-    // ── User preferences ──────────────────────────────────────
-    pub user_timezone: Option<String>,
-    pub use_24_hour_clock: bool,
-
-    // ── Modal states ──────────────────────────────────────────
+    // ── Modal flags ───────────────────────────────────────────
     pub show_about_modal: bool,
     pub show_kicad_version_modal: bool,
-    pub kicad_version: Option<String>,
 }

--- a/crates/copperforge-core/src/services.rs
+++ b/crates/copperforge-core/src/services.rs
@@ -72,4 +72,10 @@ pub struct SharedServices {
     // ── Modal flags ───────────────────────────────────────────
     pub show_about_modal: bool,
     pub show_kicad_version_modal: bool,
+
+    // ── Cross-panel summaries ─────────────────────────────────
+    /// Count of BOM entries loaded in the BOM panel. Mirror so other panels
+    /// (e.g. the Shell `status` command) can report it without reaching into
+    /// BomPanel's private state. Updated by BomPanel on extraction.
+    pub bom_component_count: usize,
 }

--- a/crates/copperforge-core/src/ui/bom_panel_v2.rs
+++ b/crates/copperforge-core/src/ui/bom_panel_v2.rs
@@ -40,7 +40,7 @@ pub fn show_bom_panel<'a>(
     let logger = ReactiveEventLogger::with_colors(logger_state, log_colors);
 
     // Get PCB path from project state
-    let pcb_path = app.project_manager.state.pcb_path().map(|p| p.to_path_buf());
+    let pcb_path = app.services.project_state.get().pcb_path().map(|p| p.to_path_buf());
 
     // Initialize BOM state if needed
     if app.bom_state.is_none() {

--- a/crates/copperforge-core/src/ui/bom_panel_v2.rs
+++ b/crates/copperforge-core/src/ui/bom_panel_v2.rs
@@ -2,12 +2,12 @@
 //!
 //! Uses kiparse to parse the PCB file directly. No live KiCad connection needed.
 
-use crate::CopperForgeApp;
-use crate::event_logger::{ReactiveEventLogger, ReactiveEventLoggerState, LogColors};
-use egui_mobius_reactive::Dynamic;
+use crate::event_logger::ReactiveEventLogger;
+use crate::services::SharedServices;
 use egui_extras::{TableBuilder, Column};
 
 /// Cached BOM state — parsed once, rendered every frame without re-parsing.
+/// Owned by the `BomPanel` citizen.
 pub struct BomPanelState {
     pub entries: Vec<crate::bom::BomEntry>,
     pub dimensions: Option<crate::bom::BoardDimensions>,
@@ -30,24 +30,23 @@ impl BomPanelState {
     }
 }
 
-/// Show the BOM panel.
-pub fn show_bom_panel<'a>(
+/// Show the BOM panel. State is owned by the caller (the BomPanel citizen).
+pub fn show_bom_panel(
     ui: &mut egui::Ui,
-    app: &mut CopperForgeApp,
-    logger_state: &'a Dynamic<ReactiveEventLoggerState>,
-    log_colors: &'a Dynamic<LogColors>,
+    state: &mut Option<BomPanelState>,
+    services: &mut SharedServices,
 ) {
-    let logger = ReactiveEventLogger::with_colors(logger_state, log_colors);
+    let logger = ReactiveEventLogger::with_colors(&services.logger_state, &services.log_colors);
 
     // Get PCB path from project state
-    let pcb_path = app.services.project_state.get().pcb_path().map(|p| p.to_path_buf());
+    let pcb_path = services.project_state.get().pcb_path().map(|p| p.to_path_buf());
 
     // Initialize BOM state if needed
-    if app.bom_state.is_none() {
-        app.bom_state = Some(BomPanelState::new());
+    if state.is_none() {
+        *state = Some(BomPanelState::new());
     }
 
-    let bom_state = app.bom_state.as_mut().unwrap();
+    let bom_state = state.as_mut().unwrap();
 
     ui.vertical(|ui| {
         // Toolbar
@@ -70,6 +69,7 @@ pub fn show_bom_panel<'a>(
                             bom_state.summary = crate::bom::component_summary(&entries);
                             bom_state.entries = entries;
                             bom_state.pcb_path_hash = path_hash;
+                            services.bom_component_count = bom_state.entries.len();
                         }
                         Err(e) => {
                             logger.log_error(&format!("BOM extraction failed: {}", e));
@@ -88,6 +88,7 @@ pub fn show_bom_panel<'a>(
                         bom_state.summary = crate::bom::component_summary(&entries);
                         bom_state.entries = entries;
                         bom_state.pcb_path_hash = path_hash;
+                        services.bom_component_count = bom_state.entries.len();
                     }
                     if let Ok(Some(dims)) = crate::bom::extract_board_dimensions(pcb) {
                         bom_state.dimensions = Some(dims);

--- a/crates/copperforge-core/src/ui/drc_panel.rs
+++ b/crates/copperforge-core/src/ui/drc_panel.rs
@@ -18,7 +18,7 @@ pub fn show_drc_panel<'a>(
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             if ui.button("🔍 Run DRC").clicked() {
                 // Check if a ruleset is loaded
-                if let Some(ref ruleset) = app.drc_manager.current_ruleset {
+                if let Some(ref ruleset) = app.services.drc_manager.current_ruleset {
                     // Run actual DRC analysis
                     logger.log_info("Starting Design Rule Check");
                     logger.log_info(&format!("Using {} ruleset", ruleset));
@@ -26,11 +26,11 @@ pub fn show_drc_panel<'a>(
                     
                     // Run the actual DRC check (now includes OpenCV)
                     // Convert ECS layers to legacy format for DRC compatibility
-                    let legacy_layers = convert_layer_store_to_legacy_layers(&app.layer_store);
+                    let legacy_layers = convert_layer_store_to_legacy_layers(&app.services.layer_store);
                     let violations = crate::drc_operations::run_simple_drc_check(
                         &legacy_layers,
-                        &app.drc_manager.rules,
-                        &mut app.drc_manager.trace_quality_issues
+                        &app.services.drc_manager.rules,
+                        &mut app.services.drc_manager.trace_quality_issues
                     );
                     
                     logger.log_info("Running imageproc edge detection and morphological analysis");
@@ -68,83 +68,83 @@ pub fn show_drc_panel<'a>(
             // Unit toggle
             ui.horizontal(|ui| {
                 ui.label("Units:");
-                ui.selectable_value(&mut app.drc_manager.rules.use_mils, false, "mm");
-                ui.selectable_value(&mut app.drc_manager.rules.use_mils, true, "mils");
+                ui.selectable_value(&mut app.services.drc_manager.rules.use_mils, false, "mm");
+                ui.selectable_value(&mut app.services.drc_manager.rules.use_mils, true, "mils");
             });
             ui.add_space(4.0);
             
             // Trace Width
             ui.horizontal(|ui| {
                 ui.label("Min Trace Width:");
-                let mut display_value = app.drc_manager.rules.get_display_value(app.drc_manager.rules.min_trace_width);
-                let range = if app.drc_manager.rules.use_mils { 2.0..=80.0 } else { 0.05..=2.0 };
-                let speed = if app.drc_manager.rules.use_mils { 0.1 } else { 0.01 };
+                let mut display_value = app.services.drc_manager.rules.get_display_value(app.services.drc_manager.rules.min_trace_width);
+                let range = if app.services.drc_manager.rules.use_mils { 2.0..=80.0 } else { 0.05..=2.0 };
+                let speed = if app.services.drc_manager.rules.use_mils { 0.1 } else { 0.01 };
                 
                 if ui.add(egui::DragValue::new(&mut display_value)
                     .speed(speed)
                     .range(range)
-                    .suffix(app.drc_manager.rules.unit_suffix())).changed() {
-                    app.drc_manager.rules.min_trace_width = app.drc_manager.rules.set_from_display(display_value);
+                    .suffix(app.services.drc_manager.rules.unit_suffix())).changed() {
+                    app.services.drc_manager.rules.min_trace_width = app.services.drc_manager.rules.set_from_display(display_value);
                 }
             });
             
             // Via Diameter  
             ui.horizontal(|ui| {
                 ui.label("Min Via Diameter:");
-                let mut display_value = app.drc_manager.rules.get_display_value(app.drc_manager.rules.min_via_diameter);
-                let range = if app.drc_manager.rules.use_mils { 4.0..=200.0 } else { 0.1..=5.0 };
-                let speed = if app.drc_manager.rules.use_mils { 0.1 } else { 0.01 };
+                let mut display_value = app.services.drc_manager.rules.get_display_value(app.services.drc_manager.rules.min_via_diameter);
+                let range = if app.services.drc_manager.rules.use_mils { 4.0..=200.0 } else { 0.1..=5.0 };
+                let speed = if app.services.drc_manager.rules.use_mils { 0.1 } else { 0.01 };
                 
                 if ui.add(egui::DragValue::new(&mut display_value)
                     .speed(speed)
                     .range(range)
-                    .suffix(app.drc_manager.rules.unit_suffix())).changed() {
-                    app.drc_manager.rules.min_via_diameter = app.drc_manager.rules.set_from_display(display_value);
+                    .suffix(app.services.drc_manager.rules.unit_suffix())).changed() {
+                    app.services.drc_manager.rules.min_via_diameter = app.services.drc_manager.rules.set_from_display(display_value);
                 }
             });
             
             // Drill Diameter
             ui.horizontal(|ui| {
                 ui.label("Min Drill Diameter:");
-                let mut display_value = app.drc_manager.rules.get_display_value(app.drc_manager.rules.min_drill_diameter);
-                let range = if app.drc_manager.rules.use_mils { 2.0..=120.0 } else { 0.05..=3.0 };
-                let speed = if app.drc_manager.rules.use_mils { 0.1 } else { 0.01 };
+                let mut display_value = app.services.drc_manager.rules.get_display_value(app.services.drc_manager.rules.min_drill_diameter);
+                let range = if app.services.drc_manager.rules.use_mils { 2.0..=120.0 } else { 0.05..=3.0 };
+                let speed = if app.services.drc_manager.rules.use_mils { 0.1 } else { 0.01 };
                 
                 if ui.add(egui::DragValue::new(&mut display_value)
                     .speed(speed)
                     .range(range)
-                    .suffix(app.drc_manager.rules.unit_suffix())).changed() {
-                    app.drc_manager.rules.min_drill_diameter = app.drc_manager.rules.set_from_display(display_value);
+                    .suffix(app.services.drc_manager.rules.unit_suffix())).changed() {
+                    app.services.drc_manager.rules.min_drill_diameter = app.services.drc_manager.rules.set_from_display(display_value);
                 }
             });
             
             // Spacing
             ui.horizontal(|ui| {
                 ui.label("Min Spacing:");
-                let mut display_value = app.drc_manager.rules.get_display_value(app.drc_manager.rules.min_spacing);
-                let range = if app.drc_manager.rules.use_mils { 2.0..=80.0 } else { 0.05..=2.0 };
-                let speed = if app.drc_manager.rules.use_mils { 0.1 } else { 0.01 };
+                let mut display_value = app.services.drc_manager.rules.get_display_value(app.services.drc_manager.rules.min_spacing);
+                let range = if app.services.drc_manager.rules.use_mils { 2.0..=80.0 } else { 0.05..=2.0 };
+                let speed = if app.services.drc_manager.rules.use_mils { 0.1 } else { 0.01 };
                 
                 if ui.add(egui::DragValue::new(&mut display_value)
                     .speed(speed)
                     .range(range)
-                    .suffix(app.drc_manager.rules.unit_suffix())).changed() {
-                    app.drc_manager.rules.min_spacing = app.drc_manager.rules.set_from_display(display_value);
+                    .suffix(app.services.drc_manager.rules.unit_suffix())).changed() {
+                    app.services.drc_manager.rules.min_spacing = app.services.drc_manager.rules.set_from_display(display_value);
                 }
             });
             
             // Annular Ring
             ui.horizontal(|ui| {
                 ui.label("Min Annular Ring:");
-                let mut display_value = app.drc_manager.rules.get_display_value(app.drc_manager.rules.min_annular_ring);
-                let range = if app.drc_manager.rules.use_mils { 2.0..=40.0 } else { 0.05..=1.0 };
-                let speed = if app.drc_manager.rules.use_mils { 0.1 } else { 0.01 };
+                let mut display_value = app.services.drc_manager.rules.get_display_value(app.services.drc_manager.rules.min_annular_ring);
+                let range = if app.services.drc_manager.rules.use_mils { 2.0..=40.0 } else { 0.05..=1.0 };
+                let speed = if app.services.drc_manager.rules.use_mils { 0.1 } else { 0.01 };
                 
                 if ui.add(egui::DragValue::new(&mut display_value)
                     .speed(speed)
                     .range(range)
-                    .suffix(app.drc_manager.rules.unit_suffix())).changed() {
-                    app.drc_manager.rules.min_annular_ring = app.drc_manager.rules.set_from_display(display_value);
+                    .suffix(app.services.drc_manager.rules.unit_suffix())).changed() {
+                    app.services.drc_manager.rules.min_annular_ring = app.services.drc_manager.rules.set_from_display(display_value);
                 }
             });
             
@@ -153,24 +153,24 @@ pub fn show_drc_panel<'a>(
             // Preset buttons
             ui.horizontal(|ui| {
                 if ui.button("🏭 JLC PCB Defaults").clicked() {
-                    app.drc_manager.rules.min_trace_width = 0.15;   // 6 mil
-                    app.drc_manager.rules.min_via_diameter = 0.3;   // 12 mil  
-                    app.drc_manager.rules.min_drill_diameter = 0.2; // 8 mil
-                    app.drc_manager.rules.min_spacing = 0.15;       // 6 mil
-                    app.drc_manager.rules.min_annular_ring = 0.1;   // 4 mil
-                    app.drc_manager.rules.use_mils = false;         // JLC uses metric
-                    app.drc_manager.current_ruleset = Some("JLC PCB".to_string());
+                    app.services.drc_manager.rules.min_trace_width = 0.15;   // 6 mil
+                    app.services.drc_manager.rules.min_via_diameter = 0.3;   // 12 mil  
+                    app.services.drc_manager.rules.min_drill_diameter = 0.2; // 8 mil
+                    app.services.drc_manager.rules.min_spacing = 0.15;       // 6 mil
+                    app.services.drc_manager.rules.min_annular_ring = 0.1;   // 4 mil
+                    app.services.drc_manager.rules.use_mils = false;         // JLC uses metric
+                    app.services.drc_manager.current_ruleset = Some("JLC PCB".to_string());
                     logger.log_info("Loaded JLC PCB design rules (0.15mm/6mil trace/space)");
                 }
                 
                 if ui.button("🔧 Conservative").clicked() {
-                    app.drc_manager.rules.min_trace_width = 0.2;    // 8 mil
-                    app.drc_manager.rules.min_via_diameter = 0.4;   // 16 mil
-                    app.drc_manager.rules.min_drill_diameter = 0.25; // 10 mil
-                    app.drc_manager.rules.min_spacing = 0.2;        // 8 mil
-                    app.drc_manager.rules.min_annular_ring = 0.15;  // 6 mil
-                    app.drc_manager.rules.use_mils = false;         // Conservative uses metric
-                    app.drc_manager.current_ruleset = Some("Conservative".to_string());
+                    app.services.drc_manager.rules.min_trace_width = 0.2;    // 8 mil
+                    app.services.drc_manager.rules.min_via_diameter = 0.4;   // 16 mil
+                    app.services.drc_manager.rules.min_drill_diameter = 0.25; // 10 mil
+                    app.services.drc_manager.rules.min_spacing = 0.2;        // 8 mil
+                    app.services.drc_manager.rules.min_annular_ring = 0.15;  // 6 mil
+                    app.services.drc_manager.rules.use_mils = false;         // Conservative uses metric
+                    app.services.drc_manager.current_ruleset = Some("Conservative".to_string());
                     logger.log_info("Loaded conservative design rules (0.2mm/8mil trace/space)");
                 }
             });
@@ -181,22 +181,22 @@ pub fn show_drc_panel<'a>(
             ui.horizontal(|ui| {
                 if ui.button("✅ Load Current Settings & Run DRC").clicked() {
                     // Create custom ruleset name from current values
-                    let unit_str = if app.drc_manager.rules.use_mils { "mils" } else { "mm" };
-                    let trace_val = app.drc_manager.rules.get_display_value(app.drc_manager.rules.min_trace_width);
-                    let space_val = app.drc_manager.rules.get_display_value(app.drc_manager.rules.min_spacing);
+                    let unit_str = if app.services.drc_manager.rules.use_mils { "mils" } else { "mm" };
+                    let trace_val = app.services.drc_manager.rules.get_display_value(app.services.drc_manager.rules.min_trace_width);
+                    let space_val = app.services.drc_manager.rules.get_display_value(app.services.drc_manager.rules.min_spacing);
                     
                     let ruleset_name = format!("Custom ({:.1}/{:.1} {unit_str} trace/space)", 
                         trace_val, space_val);
                     
-                    app.drc_manager.current_ruleset = Some(ruleset_name.clone());
+                    app.services.drc_manager.current_ruleset = Some(ruleset_name.clone());
                     
                     // Log the loaded settings
                     logger.log_info(&format!("Loaded custom design rules: {}", ruleset_name));
-                    logger.log_info(&format!("  Min Trace Width: {:.3}mm", app.drc_manager.rules.min_trace_width));
-                    logger.log_info(&format!("  Min Via Diameter: {:.3}mm", app.drc_manager.rules.min_via_diameter));
-                    logger.log_info(&format!("  Min Drill Diameter: {:.3}mm", app.drc_manager.rules.min_drill_diameter));
-                    logger.log_info(&format!("  Min Spacing: {:.3}mm", app.drc_manager.rules.min_spacing));
-                    logger.log_info(&format!("  Min Annular Ring: {:.3}mm", app.drc_manager.rules.min_annular_ring));
+                    logger.log_info(&format!("  Min Trace Width: {:.3}mm", app.services.drc_manager.rules.min_trace_width));
+                    logger.log_info(&format!("  Min Via Diameter: {:.3}mm", app.services.drc_manager.rules.min_via_diameter));
+                    logger.log_info(&format!("  Min Drill Diameter: {:.3}mm", app.services.drc_manager.rules.min_drill_diameter));
+                    logger.log_info(&format!("  Min Spacing: {:.3}mm", app.services.drc_manager.rules.min_spacing));
+                    logger.log_info(&format!("  Min Annular Ring: {:.3}mm", app.services.drc_manager.rules.min_annular_ring));
                     
                     // Run actual DRC analysis with current settings
                     logger.log_info("Starting Design Rule Check with custom settings");
@@ -204,11 +204,11 @@ pub fn show_drc_panel<'a>(
                     
                     // Run the actual DRC check (now includes OpenCV)
                     // Convert ECS layers to legacy format for DRC compatibility
-                    let legacy_layers = convert_layer_store_to_legacy_layers(&app.layer_store);
+                    let legacy_layers = convert_layer_store_to_legacy_layers(&app.services.layer_store);
                     let violations = crate::drc_operations::run_simple_drc_check(
                         &legacy_layers,
-                        &app.drc_manager.rules,
-                        &mut app.drc_manager.trace_quality_issues
+                        &app.services.drc_manager.rules,
+                        &mut app.services.drc_manager.trace_quality_issues
                     );
                     
                     logger.log_info("Running imageproc edge detection and morphological analysis");
@@ -241,7 +241,7 @@ pub fn show_drc_panel<'a>(
             ui.add_space(4.0);
             
             // Current ruleset display
-            if let Some(ref ruleset) = app.drc_manager.current_ruleset {
+            if let Some(ref ruleset) = app.services.drc_manager.current_ruleset {
                 ui.horizontal(|ui| {
                     ui.label("Current ruleset:");
                     ui.label(egui::RichText::new(ruleset).strong().color(egui::Color32::from_rgb(46, 204, 113)));
@@ -255,7 +255,7 @@ pub fn show_drc_panel<'a>(
             // PCB Manufacturer buttons
             ui.vertical(|ui| {
                 if ui.button("🏭 JLC PCB Rules").clicked() {
-                    app.drc_manager.current_ruleset = Some("JLC PCB".to_string());
+                    app.services.drc_manager.current_ruleset = Some("JLC PCB".to_string());
                     logger.log_custom(
                         LOG_TYPE_DRC,
                         "Loaded JLC PCB Design Rule Check ruleset"
@@ -263,7 +263,7 @@ pub fn show_drc_panel<'a>(
                 }
                 
                 if ui.button("🏭 PCB WAY Rules").clicked() {
-                    app.drc_manager.current_ruleset = Some("PCB WAY".to_string());
+                    app.services.drc_manager.current_ruleset = Some("PCB WAY".to_string());
                     logger.log_custom(
                         LOG_TYPE_DRC,
                         "Loaded PCB WAY Design Rule Check ruleset"
@@ -271,7 +271,7 @@ pub fn show_drc_panel<'a>(
                 }
                 
                 if ui.button("🏭 Advanced Circuits Rules").clicked() {
-                    app.drc_manager.current_ruleset = Some("Advanced Circuits".to_string());
+                    app.services.drc_manager.current_ruleset = Some("Advanced Circuits".to_string());
                     logger.log_custom(
                         LOG_TYPE_DRC,
                         "Loaded Advanced Circuits Design Rule Check ruleset"
@@ -281,15 +281,15 @@ pub fn show_drc_panel<'a>(
                 ui.add_space(4.0);
                 
                 // Clear ruleset button
-                if app.drc_manager.current_ruleset.is_some() {
+                if app.services.drc_manager.current_ruleset.is_some() {
                     if ui.button("🗑 Clear Ruleset").clicked() {
-                        if let Some(ref ruleset) = app.drc_manager.current_ruleset {
+                        if let Some(ref ruleset) = app.services.drc_manager.current_ruleset {
                             logger.log_custom(
                                 LOG_TYPE_DRC,
                                 &format!("Cleared {} Design Rule Check ruleset", ruleset)
                             );
                         }
-                        app.drc_manager.current_ruleset = None;
+                        app.services.drc_manager.current_ruleset = None;
                     }
                 }
             });
@@ -304,11 +304,11 @@ pub fn show_drc_panel<'a>(
             ui.add_space(4.0);
             
             // Show corner analysis results
-            let corner_count = app.drc_manager.trace_quality_issues.iter()
+            let corner_count = app.services.drc_manager.trace_quality_issues.iter()
                 .filter(|issue| matches!(issue.issue_type, TraceQualityType::SharpCorner))
                 .count();
                 
-            let jog_count = app.drc_manager.trace_quality_issues.iter()
+            let jog_count = app.services.drc_manager.trace_quality_issues.iter()
                 .filter(|issue| matches!(issue.issue_type, TraceQualityType::UnnecessaryJog))
                 .count();
             
@@ -342,18 +342,18 @@ pub fn show_drc_panel<'a>(
                     
                     // Run the DRC check which includes quality analysis
                     // Convert ECS layers to legacy format for DRC compatibility
-                    let legacy_layers = convert_layer_store_to_legacy_layers(&app.layer_store);
+                    let legacy_layers = convert_layer_store_to_legacy_layers(&app.services.layer_store);
                     let _violations = crate::drc_operations::run_simple_drc_check(
                         &legacy_layers,
-                        &app.drc_manager.rules,
-                        &mut app.drc_manager.trace_quality_issues
+                        &app.services.drc_manager.rules,
+                        &mut app.services.drc_manager.trace_quality_issues
                     );
                     
-                    let corner_issues = app.drc_manager.trace_quality_issues.iter()
+                    let corner_issues = app.services.drc_manager.trace_quality_issues.iter()
                         .filter(|issue| matches!(issue.issue_type, TraceQualityType::SharpCorner))
                         .count();
                         
-                    let jog_issues = app.drc_manager.trace_quality_issues.iter()
+                    let jog_issues = app.services.drc_manager.trace_quality_issues.iter()
                         .filter(|issue| matches!(issue.issue_type, TraceQualityType::UnnecessaryJog))
                         .count();
                     
@@ -361,7 +361,7 @@ pub fn show_drc_panel<'a>(
                     logger.log_info(&format!("Found {} unnecessary jogs that could be simplified", jog_issues));
                     
                     // Log details of corner issues
-                    for issue in &app.drc_manager.trace_quality_issues {
+                    for issue in &app.services.drc_manager.trace_quality_issues {
                         if matches!(issue.issue_type, TraceQualityType::SharpCorner) {
                             logger.log_warning(&format!("🔧 Corner at ({:.2}, {:.2}): {}", 
                                 issue.location.0, issue.location.1, issue.description));
@@ -377,14 +377,14 @@ pub fn show_drc_panel<'a>(
                     if ui.button("🔧 Fix Corners").clicked() {
                         logger.log_info("Starting corner rounding optimization...");
                         
-                        let corners_to_fix = app.drc_manager.trace_quality_issues.iter()
+                        let corners_to_fix = app.services.drc_manager.trace_quality_issues.iter()
                             .filter(|issue| matches!(issue.issue_type, TraceQualityType::SharpCorner))
                             .count();
                             
                         logger.log_info(&format!("Identified {} corners for rounding", corners_to_fix));
                         
                         // Clear any existing overlay
-                        app.drc_manager.corner_overlay_shapes.clear();
+                        app.services.drc_manager.corner_overlay_shapes.clear();
                         
                         // Generate corner overlay on each copper layer using KiCad-style algorithm
                         let drc = crate::drc_operations::DrcSimple::default();
@@ -392,26 +392,26 @@ pub fn show_drc_panel<'a>(
                         let mut total_fixed = 0;
                         
                         // Generate overlay for top copper
-                        if let Some(layer) = app.layer_store.find(LayerType::Copper(1)) {
+                        if let Some(layer) = app.services.layer_store.find(LayerType::Copper(1)) {
                             logger.log_info("Processing top copper layer for corner rounding...");
                             let (overlay_shapes, fixed_count) = drc.generate_corner_overlay_data(&layer.gerber, scaling_factor);
                             logger.log_info(&format!("Generated overlay for {} corners on top copper", fixed_count));
 
                             // Add overlay shapes to app state for rendering
-                            app.drc_manager.corner_overlay_shapes.extend(overlay_shapes);
+                            app.services.drc_manager.corner_overlay_shapes.extend(overlay_shapes);
                             total_fixed += fixed_count;
 
                             logger.log_info("✅ Corner overlay generated for top copper");
                         }
 
                         // Generate overlay for bottom copper
-                        if let Some(layer) = app.layer_store.find(LayerType::Copper(2)) {
+                        if let Some(layer) = app.services.layer_store.find(LayerType::Copper(2)) {
                             logger.log_info("Processing bottom copper layer for corner rounding...");
                             let (overlay_shapes, fixed_count) = drc.generate_corner_overlay_data(&layer.gerber, scaling_factor);
                             logger.log_info(&format!("Generated overlay for {} corners on bottom copper", fixed_count));
 
                             // Add overlay shapes to app state for rendering
-                            app.drc_manager.corner_overlay_shapes.extend(overlay_shapes);
+                            app.services.drc_manager.corner_overlay_shapes.extend(overlay_shapes);
                             total_fixed += fixed_count;
 
                             logger.log_info("✅ Corner overlay generated for bottom copper");
@@ -444,7 +444,7 @@ pub fn show_drc_panel<'a>(
                         }
                         
                         // Clear the quality issues as they've been processed
-                        app.drc_manager.trace_quality_issues.retain(|issue| !matches!(issue.issue_type, TraceQualityType::SharpCorner));
+                        app.services.drc_manager.trace_quality_issues.retain(|issue| !matches!(issue.issue_type, TraceQualityType::SharpCorner));
                         logger.log_info("✅ Corner analysis completed");
                     }
                 }
@@ -452,26 +452,26 @@ pub fn show_drc_panel<'a>(
             
             // Clear overlay button
             ui.horizontal(|ui| {
-                if !app.drc_manager.corner_overlay_shapes.is_empty() {
+                if !app.services.drc_manager.corner_overlay_shapes.is_empty() {
                     if ui.button("🗑 Clear Corner Overlay").clicked() {
-                        app.drc_manager.corner_overlay_shapes.clear();
+                        app.services.drc_manager.corner_overlay_shapes.clear();
                         logger.log_info("Cleared corner overlay visualization");
                     }
-                    ui.label(format!("({} overlay shapes)", app.drc_manager.corner_overlay_shapes.len()));
+                    ui.label(format!("({} overlay shapes)", app.services.drc_manager.corner_overlay_shapes.len()));
                 }
             });
             
             ui.add_space(4.0);
             
             // Show detailed issues if any exist
-            if !app.drc_manager.trace_quality_issues.is_empty() {
+            if !app.services.drc_manager.trace_quality_issues.is_empty() {
                 ui.separator();
                 ui.label("Quality Issues:");
                 
                 egui::ScrollArea::vertical()
                     .max_height(150.0)
                     .show(ui, |ui| {
-                        for (i, issue) in app.drc_manager.trace_quality_issues.iter().enumerate() {
+                        for (i, issue) in app.services.drc_manager.trace_quality_issues.iter().enumerate() {
                             ui.horizontal(|ui| {
                                 let icon = match issue.issue_type {
                                     TraceQualityType::SharpCorner => "🔧",
@@ -486,7 +486,7 @@ pub fn show_drc_panel<'a>(
                                     .color(egui::Color32::GRAY));
                             });
                             
-                            if i < app.drc_manager.trace_quality_issues.len() - 1 {
+                            if i < app.services.drc_manager.trace_quality_issues.len() - 1 {
                                 ui.separator();
                             }
                         }

--- a/crates/copperforge-core/src/ui/grid_settings.rs
+++ b/crates/copperforge-core/src/ui/grid_settings.rs
@@ -12,16 +12,16 @@ pub fn show_grid_panel<'a>(
     let logger = ReactiveEventLogger::with_colors(logger_state, log_colors);
     
     ui.add_space(4.0);
-    if ui.checkbox(&mut app.grid_settings.enabled, "Enable Grid").changed() {
+    if ui.checkbox(&mut app.services.grid_settings.enabled, "Enable Grid").changed() {
         logger.log_custom(
             LOG_TYPE_GRID,
-            &format!("Grid display {}", if app.grid_settings.enabled { "enabled" } else { "disabled" })
+            &format!("Grid display {}", if app.services.grid_settings.enabled { "enabled" } else { "disabled" })
         );
     }
     
     ui.horizontal(|ui| {
         // Get units from layer store
-        let units = &app.layer_store.units;
+        let units = &app.services.layer_store.units;
 
         let label = if units.is_mils() {
             "Grid Spacing (mils):"
@@ -30,11 +30,11 @@ pub fn show_grid_panel<'a>(
         };
         ui.label(label);
         
-        let _prev_spacing_mm = app.grid_settings.spacing_mm;
+        let _prev_spacing_mm = app.services.grid_settings.spacing_mm;
         
         if units.is_mils() {
             // Convert to mils for display using nanometer precision
-            let spacing_nm = mm_to_nm(app.grid_settings.spacing_mm as f64);
+            let spacing_nm = mm_to_nm(app.services.grid_settings.spacing_mm as f64);
             let mut spacing_mils = nm_to_mils(spacing_nm) as f32;
             let prev_mils = spacing_mils;
             
@@ -55,7 +55,7 @@ pub fn show_grid_panel<'a>(
             if slider_response.changed() || text_response.changed() {
                 // Convert back through nanometers for precision
                 let spacing_nm = mils_to_nm(spacing_mils as f64);
-                app.grid_settings.spacing_mm = nm_to_mm(spacing_nm) as f32;
+                app.services.grid_settings.spacing_mm = nm_to_mm(spacing_nm) as f32;
                 logger.log_custom(
                     LOG_TYPE_GRID,
                     &format!("Grid spacing changed from {:.1} to {:.1} mils", prev_mils, spacing_mils)
@@ -63,17 +63,17 @@ pub fn show_grid_panel<'a>(
             }
         } else {
             // Work directly in mm
-            let prev_mm = app.grid_settings.spacing_mm;
+            let prev_mm = app.services.grid_settings.spacing_mm;
             
             // Add slider
             let slider_response = ui.add(
-                egui::Slider::new(&mut app.grid_settings.spacing_mm, 0.025..=25.0)
+                egui::Slider::new(&mut app.services.grid_settings.spacing_mm, 0.025..=25.0)
                     .logarithmic(true)
             );
             
             // Add text input box next to slider
             let text_response = ui.add(
-                egui::DragValue::new(&mut app.grid_settings.spacing_mm)
+                egui::DragValue::new(&mut app.services.grid_settings.spacing_mm)
                     .speed(0.1)
                     .range(0.025..=25.0)
                     .suffix(" mm")
@@ -82,7 +82,7 @@ pub fn show_grid_panel<'a>(
             if slider_response.changed() || text_response.changed() {
                 logger.log_custom(
                     LOG_TYPE_GRID,
-                    &format!("Grid spacing changed from {:.2} to {:.2} mm", prev_mm, app.grid_settings.spacing_mm)
+                    &format!("Grid spacing changed from {:.2} to {:.2} mm", prev_mm, app.services.grid_settings.spacing_mm)
                 );
             }
         }
@@ -90,11 +90,11 @@ pub fn show_grid_panel<'a>(
     
     ui.horizontal(|ui| {
         ui.label("Grid Dot Size:");
-        let prev_dot_size = app.grid_settings.dot_size;
-        if ui.add(egui::Slider::new(&mut app.grid_settings.dot_size, 0.5..=5.0)).changed() {
+        let prev_dot_size = app.services.grid_settings.dot_size;
+        if ui.add(egui::Slider::new(&mut app.services.grid_settings.dot_size, 0.5..=5.0)).changed() {
             logger.log_custom(
                 LOG_TYPE_GRID,
-                &format!("Grid dot size changed from {:.1} to {:.1}", prev_dot_size, app.grid_settings.dot_size)
+                &format!("Grid dot size changed from {:.1} to {:.1}", prev_dot_size, app.services.grid_settings.dot_size)
             );
         }
     });
@@ -104,17 +104,17 @@ pub fn show_grid_panel<'a>(
     ui.heading("Grid Features");
     
     // Snap to grid checkbox
-    if ui.checkbox(&mut app.grid_settings.snap_enabled, "Snap to Grid").changed() {
+    if ui.checkbox(&mut app.services.grid_settings.snap_enabled, "Snap to Grid").changed() {
         logger.log_custom(
             LOG_TYPE_GRID,
-            &format!("Snap to grid {}", if app.grid_settings.snap_enabled { "enabled" } else { "disabled" })
+            &format!("Snap to grid {}", if app.services.grid_settings.snap_enabled { "enabled" } else { "disabled" })
         );
     }
     
     // Align to grid button
     ui.horizontal(|ui| {
         if ui.button("⌗ Align View to Grid (A)").clicked() {
-            crate::display::align_to_grid(&mut app.view_state, &app.grid_settings);
+            crate::display::align_to_grid(&mut app.services.view_state, &app.services.grid_settings);
             logger.log_custom(LOG_TYPE_GRID, "View aligned to grid");
         }
         
@@ -122,9 +122,9 @@ pub fn show_grid_panel<'a>(
     });
     
     // Show grid visibility status
-    if app.grid_settings.enabled {
+    if app.services.grid_settings.enabled {
         ui.separator();
-        let status = get_grid_status(&app.view_state, app.grid_settings.spacing_mm);
+        let status = get_grid_status(&app.services.view_state, app.services.grid_settings.spacing_mm);
         
         match status {
             GridStatus::TooFine => {

--- a/crates/copperforge-core/src/ui/layer_controls.rs
+++ b/crates/copperforge-core/src/ui/layer_controls.rs
@@ -16,13 +16,13 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
     // Quick controls
     ui.horizontal(|ui| {
         // All On/Off toggle
-        let visible_count = app.layer_store.visible_layers().count();
-        let total_layers = app.layer_store.layer_count();
+        let visible_count = app.services.layer_store.visible_layers().count();
+        let total_layers = app.services.layer_store.layer_count();
         let all_visible = visible_count == total_layers && total_layers > 0;
         let mut all_on = all_visible;
         if ui.checkbox(&mut all_on, "All").clicked() {
             for layer_type in LayerType::all() {
-                app.layer_store.set_visibility(layer_type, all_on);
+                app.services.layer_store.set_visibility(layer_type, all_on);
             }
             logger.log_info(if all_on { "All layers shown" } else { "All layers hidden" });
             ui.ctx().request_repaint();
@@ -32,13 +32,13 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
 
         if ui.button("Show All").clicked() {
             for layer_type in LayerType::all() {
-                app.layer_store.set_visibility(layer_type, true);
+                app.services.layer_store.set_visibility(layer_type, true);
             }
             logger.log_info("All layers shown");
         }
         if ui.button("Hide All").clicked() {
             for layer_type in LayerType::all() {
-                app.layer_store.set_visibility(layer_type, false);
+                app.services.layer_store.set_visibility(layer_type, false);
             }
             logger.log_info("All layers hidden");
         }
@@ -50,7 +50,7 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
                     LayerType::Silkscreen(Side::Bottom) | LayerType::Soldermask(Side::Bottom) | LayerType::Paste(Side::Bottom) => false,
                     LayerType::MechanicalOutline => true, // Keep outline visible
                 };
-                app.layer_store.set_visibility(layer_type, visible);
+                app.services.layer_store.set_visibility(layer_type, visible);
             }
             logger.log_info("Top layers shown");
             ui.ctx().request_repaint();
@@ -63,7 +63,7 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
                     LayerType::Silkscreen(Side::Bottom) | LayerType::Soldermask(Side::Bottom) | LayerType::Paste(Side::Bottom) => true,
                     LayerType::MechanicalOutline => true, // Keep outline visible
                 };
-                app.layer_store.set_visibility(layer_type, visible);
+                app.services.layer_store.set_visibility(layer_type, visible);
             }
             logger.log_info("Bottom layers shown");
             ui.ctx().request_repaint();
@@ -74,7 +74,7 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
                     LayerType::Silkscreen(_) | LayerType::MechanicalOutline => true,
                     _ => false, // Hide copper, soldermask, and paste layers
                 };
-                app.layer_store.set_visibility(layer_type, visible);
+                app.services.layer_store.set_visibility(layer_type, visible);
             }
             logger.log_info("Assembly layers shown (silkscreen + outline)");
             ui.ctx().request_repaint();
@@ -92,7 +92,7 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
 
     for layer_type in LayerType::all() {
         // Get layer data from layer_store
-        if let Some(layer) = app.layer_store.find(layer_type) {
+        if let Some(layer) = app.services.layer_store.find(layer_type) {
             let was_visible = layer.visible;
             let current_color = layer.color;
 
@@ -172,19 +172,19 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
 
     // Apply visibility changes
     for (layer_type, visible) in visibility_changes {
-        app.layer_store.set_visibility(layer_type, visible);
+        app.services.layer_store.set_visibility(layer_type, visible);
     }
 
     // Apply color changes
     for (layer_type, color) in color_changes {
-        app.layer_store.set_color(layer_type, color);
+        app.services.layer_store.set_color(layer_type, color);
     }
 
     // Handle deferred actions after the UI loop
     if let Some(target_layer) = show_only_layer {
         for layer_type_iter in LayerType::all() {
             let visible = layer_type_iter == target_layer;
-            app.layer_store.set_visibility(layer_type_iter, visible);
+            app.services.layer_store.set_visibility(layer_type_iter, visible);
         }
         logger.log_info(&format!("Showing only {} layer", target_layer.display_name()));
     }
@@ -199,7 +199,7 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
     }
 
     // Show unassigned gerbers section if any exist
-    if app.layer_store.has_unassigned() {
+    if app.services.layer_store.has_unassigned() {
         ui.add_space(8.0);
         ui.separator();
         ui.heading("Unassigned Gerber Files");
@@ -208,13 +208,13 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
 
         let mut assignments_to_make = Vec::new();
 
-        for unassigned in app.layer_store.unassigned.clone() {
+        for unassigned in app.services.layer_store.unassigned.clone() {
             ui.horizontal(|ui| {
                 ui.label(&unassigned.filename);
                 ui.add_space(10.0);
 
                 // Create dropdown for layer type selection
-                let layer_assignments = app.layer_store.assignments.clone();
+                let layer_assignments = app.services.layer_store.assignments.clone();
                 let current_selection = layer_assignments.get(&unassigned.filename)
                     .copied()
                     .unwrap_or(LayerType::Copper(1)); // Default selection
@@ -224,7 +224,7 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
                     .show_ui(ui, |ui| {
                         for layer_type in LayerType::all() {
                             // Check if this layer type is already assigned to another file
-                            let already_assigned = app.layer_store.find(layer_type).is_some();
+                            let already_assigned = app.services.layer_store.find(layer_type).is_some();
 
                             if already_assigned {
                                 ui.add_enabled(false, egui::Button::new(format!("✓ {} (assigned)", layer_type.display_name())));
@@ -238,10 +238,10 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
 
         // Apply assignments
         for (filename, layer_type) in assignments_to_make {
-            match app.layer_store.assign_gerber(&filename, layer_type) {
+            match app.services.layer_store.assign_gerber(&filename, layer_type) {
                 Ok(_) => {
                     logger.log_info(&format!("Assigned {} to {:?}", filename, layer_type));
-                    app.needs_initial_view = true;
+                    app.services.needs_initial_view = true;
                 }
                 Err(e) => {
                     logger.log_error(&format!("Failed to assign {}: {}", filename, e));
@@ -249,10 +249,10 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
             }
         }
 
-        if app.layer_store.has_unassigned() {
+        if app.services.layer_store.has_unassigned() {
             ui.add_space(8.0);
             if ui.button("Auto-detect All").clicked() {
-                let newly_assigned = app.layer_store.auto_assign();
+                let newly_assigned = app.services.layer_store.auto_assign();
 
                 if newly_assigned.is_empty() {
                     logger.log_warning("Could not auto-detect any remaining files");
@@ -260,7 +260,7 @@ pub fn show_layers_panel<'a>(    ui: &mut egui::Ui,
                     for (filename, layer_type) in newly_assigned {
                         logger.log_info(&format!("Auto-detected {} as {:?}", filename, layer_type));
                     }
-                    app.needs_initial_view = true;
+                    app.services.needs_initial_view = true;
                 }
             }
         }

--- a/crates/copperforge-core/src/ui/orientation_panel.rs
+++ b/crates/copperforge-core/src/ui/orientation_panel.rs
@@ -15,7 +15,7 @@ pub fn show_orientation_panel<'a>(
 #[allow(dead_code)]
 /// Export layers from quadrant view to PNG files
 pub fn export_quadrant_layers_to_png(app: &mut CopperForgeApp, logger: &ReactiveEventLogger) {
-    if !app.display_manager.quadrant_view_enabled {
+    if !app.services.display_manager.quadrant_view_enabled {
         logger.log_error("Quadrant view must be enabled to export layers as PNG");
         return;
     }

--- a/crates/copperforge-core/src/ui/project_manager_panel.rs
+++ b/crates/copperforge-core/src/ui/project_manager_panel.rs
@@ -244,223 +244,133 @@ pub fn show_create_project_dialog(
     bom_components: Vec<crate::project_manager::bom::BomComponent>,
     logger: &ReactiveEventLogger,
 ) {
-    egui::Window::new("Create New Project")
+    egui::Window::new("Import KiCad Project")
         .id(egui::Id::new("create_project_dialog"))
         .collapsible(false)
         .resizable(false)
         .movable(true)
         .default_pos(egui::Pos2::new(300.0, 150.0))
-        .min_size(egui::Vec2::new(550.0, 500.0))
+        .min_size(egui::Vec2::new(550.0, 400.0))
         .show(ctx, |ui| {
             ui.vertical(|ui| {
-                // Toggle between creating new or importing existing
+                // Handle the file dialog FIRST so auto-population runs this frame.
+                if let Some(pro_path) = manager_state.pcb_file_dialog.update(ui.ctx()).picked() {
+                    let pro_path = pro_path.to_path_buf();
+                    let should_process = manager_state.last_picked_pro_path.as_ref() != Some(&pro_path);
+                    if should_process {
+                        manager_state.last_picked_pro_path = Some(pro_path.clone());
+                        manager_state.new_project_pcb_path = Some(pro_path.with_extension("kicad_pcb"));
+                        if let Ok(meta) = crate::project_manager::kicad_metadata::read_kicad_metadata(&pro_path) {
+                            if let Some(desc) = meta.description {
+                                if manager_state.new_project_description.is_empty() {
+                                    manager_state.new_project_description = desc;
+                                }
+                            }
+                            if manager_state.new_project_name.is_empty() {
+                                if let Some(stem) = pro_path.file_stem() {
+                                    manager_state.new_project_name = stem.to_string_lossy().into_owned();
+                                }
+                            }
+                        }
+                    }
+                }
+
                 ui.horizontal(|ui| {
-                    ui.label("Project Type:");
-                    ui.radio_value(&mut manager_state.create_new_kicad_project, true, "🆕 Create New KiCad Project");
-                    ui.radio_value(&mut manager_state.create_new_kicad_project, false, "📂 Import Existing PCB");
+                    ui.label("KiCad Project File (.kicad_pro):");
+                    let pro_file_text = manager_state.new_project_pcb_path.as_ref()
+                        .map(|p| p.with_extension("kicad_pro").file_name()
+                            .map(|n| n.to_string_lossy().into_owned())
+                            .unwrap_or_else(|| "Unknown file".into()))
+                        .unwrap_or_else(|| "No KiCad project file selected".into());
+                    ui.label(&pro_file_text);
+
+                    if ui.button("Browse...").clicked() {
+                        use std::sync::Arc;
+                        use std::mem;
+                        use egui_file_dialog::FileDialog;
+                        let dialog = mem::replace(&mut manager_state.pcb_file_dialog, FileDialog::new());
+                        manager_state.pcb_file_dialog = dialog
+                            .add_file_filter("KiCad Project", Arc::new(|path: &std::path::Path| {
+                                path.extension()
+                                    .and_then(|e| e.to_str())
+                                    .map(|e| e == "kicad_pro")
+                                    .unwrap_or(false)
+                            }))
+                            .default_file_filter("KiCad Project");
+                        manager_state.pcb_file_dialog.pick_file();
+                    }
                 });
 
-                ui.separator();
                 ui.add_space(10.0);
 
-                // Common fields
                 ui.label("Project Name:");
-
                 ui.horizontal(|ui| {
-                    // Text entry field always visible for editing
                     ui.text_edit_singleline(&mut manager_state.new_project_name);
-
-                    // Show ComboBox with recent project names
                     egui::ComboBox::from_id_salt("project_name_combo_dialog")
                         .selected_text("📋 Recent")
                         .show_ui(ui, |ui| {
-                            if !manager_state.recent_project_names.is_empty() {
-                                // Clone the list to avoid borrow issues
-                                let recent_names = manager_state.recent_project_names.clone();
-                                for recent_name in &recent_names {
-                                    if ui.selectable_label(false, recent_name).clicked() {
-                                        // Load full project metadata (name, description, tags)
-                                        manager_state.load_project_metadata_into_form(recent_name);
+                            if manager_state.recent_project_names.is_empty() {
+                                ui.label(egui::RichText::new("No recent projects").small().italics());
+                            } else {
+                                let recent = manager_state.recent_project_names.clone();
+                                for n in &recent {
+                                    if ui.selectable_label(false, n).clicked() {
+                                        manager_state.load_project_metadata_into_form(n);
                                     }
                                 }
-                            } else {
-                                ui.label(egui::RichText::new("No recent projects").small().italics());
                             }
                         });
                 });
 
                 ui.add_space(5.0);
-
                 ui.label("Description:");
                 ui.text_edit_multiline(&mut manager_state.new_project_description);
 
                 ui.add_space(5.0);
-
                 ui.label("Tags (comma-separated):");
                 ui.text_edit_singleline(&mut manager_state.new_project_tags);
 
-                ui.add_space(10.0);
-
-                // Show different fields based on project type
-                if manager_state.create_new_kicad_project {
-                    ui.heading("New KiCad Project Settings");
-                    ui.separator();
-
-                    // Location
-                    ui.horizontal(|ui| {
-                        ui.label("Location:");
-                        let location_text = manager_state.new_kicad_project_location
-                            .to_string_lossy()
-                            .to_string();
-                        ui.label(&location_text);
-
-                        if ui.button("Browse...").clicked() {
-                            manager_state.location_dialog.pick_directory();
-                        }
-                    });
-
-                    // Handle location dialog
-                    if let Some(path) = manager_state.location_dialog.update(ui.ctx()).picked() {
-                        manager_state.new_kicad_project_location = path.to_path_buf();
-                    }
-
-                    ui.add_space(5.0);
-
-                    // Author
-                    ui.horizontal(|ui| {
-                        ui.label("Author:");
-                        ui.text_edit_singleline(&mut manager_state.new_kicad_project_author);
-                    });
-
-                    ui.add_space(5.0);
-
-                    // Company
-                    ui.horizontal(|ui| {
-                        ui.label("Company:");
-                        ui.text_edit_singleline(&mut manager_state.new_kicad_project_company);
-                    });
-
-                    ui.add_space(10.0);
-
-                    // Library options
-                    ui.heading("Library Configuration");
-                    ui.separator();
-
-                    ui.checkbox(&mut manager_state.include_kiverse, "Include KiVerse Symbol Library");
-                    ui.checkbox(&mut manager_state.include_atlantix_resistors, "Include Atlantix-EDA Resistor Library");
-
-                    ui.add_space(5.0);
-
-                    // KiVerse path
-                    ui.horizontal(|ui| {
-                        ui.label("KiVerse Path:");
-                        let kiverse_text = manager_state.kiverse_path
-                            .to_string_lossy()
-                            .to_string();
-                        ui.label(&kiverse_text);
-                    });
-                    ui.label("💡 Default: ~/kiverse");
-
-                } else {
-                    // Import existing KiCad project
-                    ui.horizontal(|ui| {
-                        ui.label("KiCad Project File (.kicad_pro):");
-
-                        let pcb_file_text = if let Some(ref path) = manager_state.new_project_pcb_path {
-                            path.file_name()
-                                .map(|n| n.to_string_lossy().to_string())
-                                .unwrap_or_else(|| "Unknown file".to_string())
-                        } else {
-                            "No KiCad project file selected".to_string()
-                        };
-
-                        ui.label(&pcb_file_text);
-
-                        if ui.button("Browse...").clicked() {
-                            use std::sync::Arc;
-                            use std::mem;
-                            use egui_file_dialog::FileDialog;
-
-                            // Take the dialog, add filter, and put it back
-                            let dialog = mem::replace(&mut manager_state.pcb_file_dialog, FileDialog::new());
-                            manager_state.pcb_file_dialog = dialog
-                                .add_file_filter("KiCad Project", Arc::new(|path: &std::path::Path| {
-                                    path.extension()
-                                        .and_then(|ext| ext.to_str())
-                                        .map(|ext| ext == "kicad_pro")
-                                        .unwrap_or(false)
-                                }));
-                            manager_state.pcb_file_dialog.pick_file();
-                        }
-                    });
-
-                    // Handle KiCad project file dialog
-                    if let Some(pro_path) = manager_state.pcb_file_dialog.update(ui.ctx()).picked() {
-                        // Convert .kicad_pro path to .kicad_pcb path
-                        let pcb_path = pro_path.with_extension("kicad_pcb");
-                        manager_state.new_project_pcb_path = Some(pcb_path);
-                    }
-                }
-
                 ui.add_space(15.0);
 
-                // Buttons
                 ui.horizontal(|ui| {
-                    if ui.button("Create").clicked() {
-                        // Validate input
+                    if ui.button("📥 Import").clicked() {
                         if manager_state.new_project_name.trim().is_empty() {
-                            manager_state.last_error = Some("Project name cannot be empty".to_string());
+                            manager_state.last_error = Some("Project name cannot be empty".into());
                             return;
                         }
-
-                        // Parse tags
+                        let pcb_path = match manager_state.new_project_pcb_path.clone() {
+                            Some(p) => p,
+                            None => {
+                                manager_state.last_error = Some("Please select a .kicad_pro file first".into());
+                                return;
+                            }
+                        };
                         let tags: Vec<String> = manager_state.new_project_tags
                             .split(',')
                             .map(|s| s.trim().to_string())
                             .filter(|s| !s.is_empty())
                             .collect();
-
-                        // Create project based on type
-                        let result = if manager_state.create_new_kicad_project {
-                            // Create new KiCad project from scratch
-                            manager_state.create_new_kicad_project_from_scratch(
-                                manager_state.new_project_name.clone(),
-                                manager_state.new_project_description.clone(),
-                                tags,
-                            )
-                        } else {
-                            // Import existing PCB
-                            let pcb_path = if let Some(ref path) = manager_state.new_project_pcb_path {
-                                path.clone()
-                            } else {
-                                manager_state.last_error = Some("Please select a PCB file first".to_string());
-                                return;
-                            };
-
-                            manager_state.create_project(
-                                manager_state.new_project_name.clone(),
-                                manager_state.new_project_description.clone(),
-                                pcb_path,
-                                tags,
-                                bom_components.clone(),
-                            )
-                        };
-
-                        match result {
-                            Ok(project_id) => {
-                                logger.log_info(&format!("Created project: {} (ID: {})", manager_state.new_project_name, project_id));
-                                // Only reset on success - this keeps user preferences but clears project fields
+                        match manager_state.create_project(
+                            manager_state.new_project_name.clone(),
+                            manager_state.new_project_description.clone(),
+                            pcb_path,
+                            tags,
+                            bom_components.clone(),
+                        ) {
+                            Ok(id) => {
+                                logger.log_info(&format!(
+                                    "Imported project: {} (ID: {})",
+                                    manager_state.new_project_name, id
+                                ));
                                 manager_state.reset_create_dialog();
                             }
                             Err(e) => {
-                                // Don't reset on error - user can fix the issue and try again
-                                manager_state.last_error = Some(format!("Failed to create project: {}", e));
+                                manager_state.last_error = Some(format!("Failed to import: {}", e));
                             }
                         }
                     }
 
                     if ui.button("Cancel").clicked() {
-                        // On cancel, hide dialog but keep fields for next time
                         manager_state.show_create_dialog = false;
                     }
                 });

--- a/crates/copperforge-core/src/ui/project_manager_panel.rs
+++ b/crates/copperforge-core/src/ui/project_manager_panel.rs
@@ -20,7 +20,7 @@ pub fn show_project_manager_panel(
         None
     };
     
-    let project_state = &app.project_manager.state;
+    let project_state = &app.services.project_state.get();
     
     if let Some(ref mut manager_state) = app.project_manager_state {
         // Handle any errors

--- a/crates/copperforge-core/src/ui/project_manager_panel.rs
+++ b/crates/copperforge-core/src/ui/project_manager_panel.rs
@@ -14,7 +14,7 @@ pub fn show_project_manager_panel(
     let logger = ReactiveEventLogger::with_colors(logger_state, log_colors);
     
     // Split app borrow to avoid conflicts
-    let bom_components: Option<Vec<crate::project_manager::bom::BomComponent>> = if let Some(ref bom_state) = app.bom_state {
+    let bom_components: Option<Vec<crate::project_manager::bom::BomComponent>> = if let Some(ref bom_state) = app.bom_panel.state {
         Some(bom_state.entries.iter().cloned().map(Into::into).collect())
     } else {
         None

--- a/crates/copperforge-core/src/ui/project_panel.rs
+++ b/crates/copperforge-core/src/ui/project_panel.rs
@@ -283,7 +283,7 @@ fn show_create_project_form(
                             .collect();
 
                         // Get BOM components
-                        let bom_components: Vec<crate::project_manager::bom::BomComponent> = if let Some(ref bom_state) = app.bom_state {
+                        let bom_components: Vec<crate::project_manager::bom::BomComponent> = if let Some(ref bom_state) = app.bom_panel.state {
                             bom_state.entries.iter().cloned().map(Into::into).collect()
                         } else {
                             Vec::new()

--- a/crates/copperforge-core/src/ui/project_panel.rs
+++ b/crates/copperforge-core/src/ui/project_panel.rs
@@ -31,10 +31,10 @@ fn show_create_project_form(
 ) {
     // Initialize project manager state if not already done
     if app.project_manager_state.is_none() {
-        let mut state = ProjectManagerState::with_config(&app.project_manager.config);
+        let mut state = ProjectManagerState::with_config(&app.services.config);
 
         // Initialize database
-        let db_path = app.config_path.join("projects.db");
+        let db_path = app.services.config_path.join("projects.db");
         if let Err(e) = state.initialize_database(&db_path) {
             logger.log_error(&format!("Failed to initialize project database: {}", e));
         }
@@ -218,7 +218,7 @@ fn show_create_project_form(
                                     }));
 
                                 // Set initial directory from preferences if available
-                                if let Some(ref preferred_dir) = app.project_manager.config.preferred_projects_directory {
+                                if let Some(ref preferred_dir) = app.services.config.preferred_projects_directory {
                                     dialog = dialog.initial_directory(preferred_dir.clone());
                                 }
 

--- a/crates/copperforge-core/src/ui/project_panel.rs
+++ b/crates/copperforge-core/src/ui/project_panel.rs
@@ -1,3 +1,8 @@
+//! Project tab — Import an existing KiCad project into the CopperForge DB.
+//!
+//! This tab is import-only. Creating brand-new KiCad projects from templates
+//! is available via the Shell panel's `new-project` command.
+
 use crate::CopperForgeApp;
 use crate::project_manager::ProjectManagerState;
 use crate::event_logger::{ReactiveEventLogger, ReactiveEventLoggerState, LogColors};
@@ -12,324 +17,175 @@ pub fn show_project_panel<'a>(
 ) {
     let logger = ReactiveEventLogger::with_colors(logger_state, log_colors);
 
-    ui.heading("➕ Create New Project");
+    ui.heading("📥 Import KiCad Project");
     ui.separator();
 
-    // Use a scroll area to ensure all content is visible
     egui::ScrollArea::vertical()
         .auto_shrink([false, false])
         .show(ui, |ui| {
-            show_create_project_form(ui, app, &logger);
+            show_import_form(ui, app, &logger);
         });
 }
 
-/// Show create project form (static, not modal)
-fn show_create_project_form(
+fn show_import_form(
     ui: &mut egui::Ui,
     app: &mut CopperForgeApp,
     logger: &ReactiveEventLogger,
 ) {
-    // Initialize project manager state if not already done
+    // Initialize project manager state (clones the shared DB handle).
     if app.project_manager_state.is_none() {
         let mut state = ProjectManagerState::with_config(&app.services.config);
-
-        // Initialize database
-        let db_path = app.services.config_path.join("projects.db");
-        if let Err(e) = state.initialize_database(&db_path) {
+        if let Err(e) = state.initialize_database(&app.services.project_db) {
             logger.log_error(&format!("Failed to initialize project database: {}", e));
         }
-
         app.project_manager_state = Some(state);
     }
 
-    if let Some(ref mut manager_state) = app.project_manager_state {
-        // Handle any errors
-        if let Some(error) = manager_state.last_error.take() {
-            logger.log_error(&error);
+    let manager_state = match app.project_manager_state.as_mut() {
+        Some(s) => s,
+        None => return,
+    };
+
+    if let Some(error) = manager_state.last_error.take() {
+        logger.log_error(&error);
+    }
+
+    ui.vertical(|ui| {
+        // ── File pick flow ────────────────────────────────────
+        // Handle the dialog pick *first* so UI below reflects new values this frame.
+        if let Some(pro_path) = manager_state.pcb_file_dialog.update(ui.ctx()).picked() {
+            let pro_path = pro_path.to_path_buf();
+            let should_process = manager_state.last_picked_pro_path.as_ref() != Some(&pro_path);
+
+            if should_process {
+                manager_state.last_picked_pro_path = Some(pro_path.clone());
+                manager_state.new_project_pcb_path = Some(pro_path.with_extension("kicad_pcb"));
+
+                // Auto-fill from .kicad_pro metadata.
+                match crate::project_manager::kicad_metadata::read_kicad_metadata(&pro_path) {
+                    Ok(metadata) => {
+                        let mut missing = Vec::new();
+                        if metadata.author.is_none() { missing.push("Author"); }
+                        if metadata.company.is_none() { missing.push("Company"); }
+
+                        if let Some(desc) = metadata.description {
+                            if manager_state.new_project_description.is_empty() {
+                                manager_state.new_project_description = desc;
+                            }
+                        }
+
+                        if manager_state.new_project_name.is_empty() {
+                            if let Some(stem) = pro_path.file_stem() {
+                                manager_state.new_project_name = stem.to_string_lossy().into_owned();
+                            }
+                        }
+
+                        logger.log_info(&format!("Loaded pedigree from: {}", pro_path.display()));
+                        if !missing.is_empty() {
+                            logger.log_warning(&format!(
+                                "Missing pedigree fields in .kicad_pro: {} — set in KiCad → Project Properties",
+                                missing.join(", ")
+                            ));
+                        }
+                    }
+                    Err(e) => logger.log_warning(&format!("Could not read pedigree: {}", e)),
+                }
+            }
         }
 
-        ui.vertical(|ui| {
-                    // Toggle between creating new or importing existing
-                    ui.horizontal(|ui| {
-                        ui.label("Project Type:");
-                    });
-                    ui.radio_value(&mut manager_state.create_new_kicad_project, true, "🆕 Create New KiCad Project");
-                    ui.radio_value(&mut manager_state.create_new_kicad_project, false, "📂 Import Existing PCB");
+        // ── File picker ───────────────────────────────────────
+        ui.horizontal(|ui| {
+            ui.label("KiCad Project File (.kicad_pro):");
+            if ui.button("Browse...").clicked() {
+                use std::sync::Arc;
+                use std::mem;
 
-                    ui.add_space(5.0);
-
-                    // Common fields
-                    ui.label("Project Name:");
-
-                    ui.horizontal(|ui| {
-                        // Text entry field always visible for editing
-                        ui.text_edit_singleline(&mut manager_state.new_project_name);
-
-                        // Show ComboBox with recent project names
-                        egui::ComboBox::from_id_salt("project_name_combo")
-                            .selected_text("📋 Recent")
-                            .show_ui(ui, |ui| {
-                                if !manager_state.recent_project_names.is_empty() {
-                                    // Clone the list to avoid borrow issues
-                                    let recent_names = manager_state.recent_project_names.clone();
-                                    for recent_name in &recent_names {
-                                        if ui.selectable_label(false, recent_name).clicked() {
-                                            // Load full project metadata (name, description, tags)
-                                            manager_state.load_project_metadata_into_form(recent_name);
-                                        }
-                                    }
-                                } else {
-                                    ui.label(egui::RichText::new("No recent projects").small().italics());
-                                }
-                            });
-                    });
-
-                    ui.add_space(3.0);
-
-                    ui.label("Description:");
-                    ui.text_edit_multiline(&mut manager_state.new_project_description);
-
-                    ui.add_space(3.0);
-
-                    ui.label("Tags (comma-separated):");
-                    ui.text_edit_singleline(&mut manager_state.new_project_tags);
-
-                    ui.add_space(5.0);
-
-                    // Show different fields based on project type
-                    if manager_state.create_new_kicad_project {
-                        ui.label(egui::RichText::new("New KiCad Project Settings").strong());
-                        ui.separator();
-
-                        egui::Grid::new("kicad_project_settings_grid")
-                            .num_columns(2)
-                            .spacing([10.0, 5.0])
-                            .show(ui, |ui| {
-                                // Location
-                                ui.label("Location:");
-                                ui.horizontal(|ui| {
-                                    let location_text = manager_state.new_kicad_project_location
-                                        .to_string_lossy()
-                                        .to_string();
-                                    ui.label(egui::RichText::new(&location_text).small().monospace());
-                                    if ui.button("Browse...").clicked() {
-                                        manager_state.location_dialog.pick_directory();
-                                    }
-                                });
-                                ui.end_row();
-
-                                // Author
-                                ui.label("Author:");
-                                ui.text_edit_singleline(&mut manager_state.new_kicad_project_author);
-                                ui.end_row();
-
-                                // Company
-                                ui.label("Company:");
-                                ui.text_edit_singleline(&mut manager_state.new_kicad_project_company);
-                                ui.end_row();
-                            });
-
-                        // Handle location dialog
-                        if let Some(path) = manager_state.location_dialog.update(ui.ctx()).picked() {
-                            manager_state.new_kicad_project_location = path.to_path_buf();
-                        }
-
-                    } else {
-                        // Import existing KiCad project
-                        ui.label(egui::RichText::new("Import Existing KiCad Project").strong());
-                        ui.separator();
-
-                        // Handle KiCad project file dialog FIRST (before UI rendering)
-                        if let Some(pro_path) = manager_state.pcb_file_dialog.update(ui.ctx()).picked() {
-                            let pro_path = pro_path.to_path_buf();
-
-                            // Only process if this is a NEW file selection (not already processed)
-                            let should_process = manager_state.last_picked_pro_path.as_ref() != Some(&pro_path);
-
-                            if should_process {
-                                // Store the path to prevent re-processing
-                                manager_state.last_picked_pro_path = Some(pro_path.clone());
-
-                                // Convert .kicad_pro path to .kicad_pcb path
-                                let pcb_path = pro_path.with_extension("kicad_pcb");
-                                manager_state.new_project_pcb_path = Some(pcb_path);
-
-                                // Read pedigree information from .kicad_pro file
-                                match crate::project_manager::kicad_metadata::read_kicad_metadata(&pro_path) {
-                                    Ok(metadata) => {
-                                        let mut missing_fields = Vec::new();
-
-                                        // Auto-populate form fields with pedigree data
-                                        if let Some(author) = metadata.author {
-                                            manager_state.new_kicad_project_author = author;
-                                        } else {
-                                            missing_fields.push("Author");
-                                        }
-
-                                        if let Some(company) = metadata.company {
-                                            manager_state.new_kicad_project_company = company;
-                                        } else {
-                                            missing_fields.push("Company");
-                                        }
-
-                                        if let Some(description) = metadata.description {
-                                            // Only populate if empty to avoid overwriting user input
-                                            if manager_state.new_project_description.is_empty() {
-                                                manager_state.new_project_description = description;
-                                            }
-                                        }
-
-                                        // Use filename as project name if not already set
-                                        if manager_state.new_project_name.is_empty() {
-                                            if let Some(file_stem) = pro_path.file_stem() {
-                                                manager_state.new_project_name = file_stem.to_string_lossy().to_string();
-                                            }
-                                        }
-
-                                        logger.log_info(&format!("Loaded pedigree from: {}", pro_path.display()));
-
-                                        // Warn about missing pedigree fields
-                                        if !missing_fields.is_empty() {
-                                            logger.log_warning(&format!("Missing pedigree information in .kicad_pro: {}", missing_fields.join(", ")));
-                                        }
-                                    }
-                                    Err(e) => {
-                                        logger.log_warning(&format!("Could not read pedigree from .kicad_pro: {}", e));
-                                    }
-                                }
-                            }
-                        }
-
-                        ui.horizontal(|ui| {
-                            ui.label("KiCad Project File (.kicad_pro):");
-
-                            if ui.button("Browse...").clicked() {
-                                use std::sync::Arc;
-                                use std::mem;
-
-                                // Take the dialog, add filter, and put it back
-                                let dialog = mem::replace(&mut manager_state.pcb_file_dialog, FileDialog::new());
-                                let mut dialog = dialog
-                                    .add_file_filter("KiCad Project", Arc::new(|path: &std::path::Path| {
-                                        path.extension()
-                                            .and_then(|ext| ext.to_str())
-                                            .map(|ext| ext == "kicad_pro")
-                                            .unwrap_or(false)
-                                    }));
-
-                                // Set initial directory from preferences if available
-                                if let Some(ref preferred_dir) = app.services.config.preferred_projects_directory {
-                                    dialog = dialog.initial_directory(preferred_dir.clone());
-                                }
-
-                                manager_state.pcb_file_dialog = dialog;
-                                manager_state.pcb_file_dialog.pick_file();
-                            }
-                        });
-
-                        let pcb_file_text = if let Some(ref path) = manager_state.new_project_pcb_path {
-                            path.file_name()
-                                .map(|n| n.to_string_lossy().to_string())
-                                .unwrap_or_else(|| "Unknown file".to_string())
-                        } else {
-                            "No KiCad project file selected".to_string()
-                        };
-                        ui.label(egui::RichText::new(&pcb_file_text).small().monospace());
-
-                        ui.add_space(5.0);
-
-                        // Show pedigree fields (auto-populated from .kicad_pro)
-                        ui.label(egui::RichText::new("Pedigree Information").strong());
-                        ui.label(egui::RichText::new("💡 These fields are auto-populated from the .kicad_pro file").small().italics());
-                        ui.separator();
-
-                        egui::Grid::new("import_pedigree_grid")
-                            .num_columns(2)
-                            .spacing([10.0, 5.0])
-                            .show(ui, |ui| {
-                                // Author
-                                ui.label("Author:");
-                                ui.text_edit_singleline(&mut manager_state.new_kicad_project_author);
-                                ui.end_row();
-
-                                // Company
-                                ui.label("Company:");
-                                ui.text_edit_singleline(&mut manager_state.new_kicad_project_company);
-                                ui.end_row();
-                            });
-                    }
-
-                    ui.add_space(10.0);
-
-                    // Button text changes based on mode
-                    let button_text = if manager_state.create_new_kicad_project {
-                        "✅ Create Project"
-                    } else {
-                        "📥 Import Project"
-                    };
-
-                    if ui.button(button_text).clicked() {
-                        // Validate input
-                        if manager_state.new_project_name.trim().is_empty() {
-                            manager_state.last_error = Some("Project name cannot be empty".to_string());
-                            return;
-                        }
-
-                        // Parse tags
-                        let tags: Vec<String> = manager_state.new_project_tags
-                            .split(',')
-                            .map(|s| s.trim().to_string())
-                            .filter(|s| !s.is_empty())
-                            .collect();
-
-                        // Get BOM components
-                        let bom_components: Vec<crate::project_manager::bom::BomComponent> = if let Some(ref bom_state) = app.bom_panel.state {
-                            bom_state.entries.iter().cloned().map(Into::into).collect()
-                        } else {
-                            Vec::new()
-                        };
-
-                        // Create project based on type
-                        let result = if manager_state.create_new_kicad_project {
-                            // Create new KiCad project from scratch
-                            manager_state.create_new_kicad_project_from_scratch(
-                                manager_state.new_project_name.clone(),
-                                manager_state.new_project_description.clone(),
-                                tags,
-                            )
-                        } else {
-                            // Import existing PCB
-                            let pcb_path = if let Some(ref path) = manager_state.new_project_pcb_path {
-                                path.clone()
-                            } else {
-                                manager_state.last_error = Some("Please select a PCB file first".to_string());
-                                return;
-                            };
-
-                            manager_state.create_project(
-                                manager_state.new_project_name.clone(),
-                                manager_state.new_project_description.clone(),
-                                pcb_path,
-                                tags,
-                                bom_components,
-                            )
-                        };
-
-                        match result {
-                            Ok(project_id) => {
-                                let action = if manager_state.create_new_kicad_project { "Created" } else { "Imported" };
-                                logger.log_info(&format!("{} project: {} (ID: {})", action, manager_state.new_project_name, project_id));
-                                // Only reset on success - this keeps user preferences but clears project fields
-                                manager_state.reset_create_dialog();
-                            }
-                            Err(e) => {
-                                // Don't reset on error - user can fix the issue and try again
-                                let action = if manager_state.create_new_kicad_project { "create" } else { "import" };
-                                manager_state.last_error = Some(format!("Failed to {} project: {}", action, e));
-                            }
-                        }
-                    }
+                let dialog = mem::replace(&mut manager_state.pcb_file_dialog, FileDialog::new());
+                let mut dialog = dialog
+                    .add_file_filter("KiCad Project", Arc::new(|path: &std::path::Path| {
+                        path.extension()
+                            .and_then(|e| e.to_str())
+                            .map(|e| e == "kicad_pro")
+                            .unwrap_or(false)
+                    }))
+                    .default_file_filter("KiCad Project");
+                if let Some(ref dir) = app.services.config.preferred_projects_directory {
+                    dialog = dialog.initial_directory(dir.clone());
+                }
+                manager_state.pcb_file_dialog = dialog;
+                manager_state.pcb_file_dialog.pick_file();
+            }
         });
-    }
-}
 
+        let picked_label = manager_state.new_project_pcb_path.as_ref()
+            .map(|p| p.with_extension("kicad_pro").file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "Unknown file".into()))
+            .unwrap_or_else(|| "No KiCad project file selected".into());
+        ui.label(egui::RichText::new(&picked_label).small().monospace());
+
+        ui.add_space(8.0);
+
+        // ── Metadata fields (editable) ────────────────────────
+        ui.label("Project Name:");
+        ui.text_edit_singleline(&mut manager_state.new_project_name);
+        ui.add_space(3.0);
+
+        ui.label("Description:");
+        ui.text_edit_multiline(&mut manager_state.new_project_description);
+        ui.add_space(3.0);
+
+        ui.label("Tags (comma-separated):");
+        ui.text_edit_singleline(&mut manager_state.new_project_tags);
+        ui.add_space(10.0);
+
+        // ── Import button ─────────────────────────────────────
+        if ui.button("📥 Import Project").clicked() {
+            if manager_state.new_project_name.trim().is_empty() {
+                manager_state.last_error = Some("Project name cannot be empty".into());
+                return;
+            }
+            let pcb_path = match manager_state.new_project_pcb_path.clone() {
+                Some(p) => p,
+                None => {
+                    manager_state.last_error = Some("Please select a .kicad_pro file first".into());
+                    return;
+                }
+            };
+
+            let tags: Vec<String> = manager_state.new_project_tags
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+
+            let bom_components: Vec<crate::project_manager::bom::BomComponent> =
+                if let Some(ref bom_state) = app.bom_panel.state {
+                    bom_state.entries.iter().cloned().map(Into::into).collect()
+                } else {
+                    Vec::new()
+                };
+
+            let result = manager_state.create_project(
+                manager_state.new_project_name.clone(),
+                manager_state.new_project_description.clone(),
+                pcb_path,
+                tags,
+                bom_components,
+            );
+
+            match result {
+                Ok(id) => {
+                    logger.log_info(&format!(
+                        "Imported project: {} (ID: {})",
+                        manager_state.new_project_name, id
+                    ));
+                    manager_state.reset_create_dialog();
+                }
+                Err(e) => {
+                    manager_state.last_error = Some(format!("Failed to import project: {}", e));
+                }
+            }
+        }
+    });
+}

--- a/crates/copperforge-core/src/ui/projects_panel.rs
+++ b/crates/copperforge-core/src/ui/projects_panel.rs
@@ -34,10 +34,10 @@ pub fn show_projects_panel<'a>(
 
     // Initialize project manager state if not already done
     if app.project_manager_state.is_none() {
-        let mut state = ProjectManagerState::with_config(&app.project_manager.config);
+        let mut state = ProjectManagerState::with_config(&app.services.config);
 
         // Initialize database
-        let db_path = app.config_path.join("projects.db");
+        let db_path = app.services.config_path.join("projects.db");
         if let Err(e) = state.initialize_database(&db_path) {
             logger.log_error(&format!("Failed to initialize project database: {}", e));
         }
@@ -638,9 +638,9 @@ pub fn show_projects_panel<'a>(
                 // Successfully loaded project data, now restore the project state
                 if let Some(ref project) = manager_state.current_project {
                     // 1. Set the PCB file path in the project manager
-                    app.project_manager.state = crate::project::ProjectState::PcbSelected {
-                        pcb_path: project.metadata.pcb_file_path.clone()
-                    };
+                    app.services.project_state.set(crate::project::ProjectState::PcbSelected {
+                        pcb_path: project.metadata.pcb_file_path.clone(),
+                    });
 
                     // 2. Restore BOM components if available
                     if !project.bom_components.is_empty() {

--- a/crates/copperforge-core/src/ui/projects_panel.rs
+++ b/crates/copperforge-core/src/ui/projects_panel.rs
@@ -78,7 +78,7 @@ pub fn show_projects_panel<'a>(
 
                 // Save BOM to current project
                 if ui.button("💾 Save BOM").clicked() {
-                    if let Some(ref bom_state) = app.bom_state {
+                    if let Some(ref bom_state) = app.bom_panel.state {
                         let components: Vec<crate::project_manager::bom::BomComponent> = bom_state.entries.iter().cloned().map(Into::into).collect();
                         if let Err(e) = manager_state.update_project_bom(components) {
                             manager_state.last_error = Some(format!("Failed to save BOM: {}", e));
@@ -644,7 +644,7 @@ pub fn show_projects_panel<'a>(
 
                     // 2. Restore BOM components if available
                     if !project.bom_components.is_empty() {
-                        if let Some(ref mut bom_state) = app.bom_state {
+                        if let Some(ref mut bom_state) = app.bom_panel.state {
                             bom_state.entries = project.bom_components.iter().map(|c| {
                                 crate::bom::BomEntry {
                                     item: c.item_number.parse().unwrap_or(0),

--- a/crates/copperforge-core/src/ui/projects_panel.rs
+++ b/crates/copperforge-core/src/ui/projects_panel.rs
@@ -4,7 +4,7 @@ use crate::project_manager::database::ProjectMetadata;
 use crate::event_logger::{ReactiveEventLogger, ReactiveEventLoggerState, LogColors};
 use egui_mobius_reactive::Dynamic;
 use std::collections::HashMap;
-use egui_ltreeview::{TreeView, Action};
+use egui_ltreeview::{TreeView, Action, NodeBuilder};
 
 /// Right-click intents on a project row, deposited into egui memory by the
 /// context-menu closure and dispatched after `TreeView::show` returns.
@@ -35,13 +35,9 @@ pub fn show_projects_panel<'a>(
     // Initialize project manager state if not already done
     if app.project_manager_state.is_none() {
         let mut state = ProjectManagerState::with_config(&app.services.config);
-
-        // Initialize database
-        let db_path = app.services.config_path.join("projects.db");
-        if let Err(e) = state.initialize_database(&db_path) {
+        if let Err(e) = state.initialize_database(&app.services.project_db) {
             logger.log_error(&format!("Failed to initialize project database: {}", e));
         }
-
         app.project_manager_state = Some(state);
     }
 
@@ -137,316 +133,107 @@ pub fn show_projects_panel<'a>(
 
             let selected_project_id = manager_state.selected_project_id.clone();
 
-            // Two-column layout: tree view on left, details on right
-            ui.columns(2, |columns| {
-                // Left column: Tree view
-                columns[0].vertical(|ui| {
-                    ui.heading("Projects");
-                    ui.separator();
+            // Full-width tree (right-pane details moved to a modal opened via
+            // right-click → Update, or double-click on a project to load it).
+            ui.heading("Projects");
+            ui.add_space(6.0);
 
-                    egui::ScrollArea::vertical()
-                        .auto_shrink([false, false])
-                        .show(ui, |ui| {
-                            let (_response, actions) = TreeView::new(ui.make_persistent_id("projects_tree"))
-                                .fallback_context_menu(|ui, selected| {
-                                    // `selected` is ltreeview's current selection (last left-clicked node).
-                                    // Derive the project id from it (handles "proj_123:sheet_0" node ids).
-                                    let project_id_opt: Option<String> = selected.first().map(|s: &String| {
-                                        if let Some((head, _)) = s.split_once(':') {
-                                            head.to_string()
-                                        } else {
-                                            s.clone()
-                                        }
-                                    });
+            egui::ScrollArea::vertical()
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    let (_response, actions) = TreeView::new(ui.make_persistent_id("projects_tree"))
+                        .fallback_context_menu(|ui, selected| {
+                            // Derive project id from selection. Rev-node ids look
+                            // like "proj_X:rev:rev_01" — we want "proj_X".
+                            let sel_id: Option<String> = selected.first().cloned();
+                            let project_id_opt: Option<String> = sel_id.as_deref().map(|s| {
+                                s.split_once(':').map(|(head, _)| head.to_string()).unwrap_or_else(|| s.to_string())
+                            });
+                            let is_release_node = sel_id.as_deref().map(|s| s.contains(":rev:")).unwrap_or(false);
 
-                                    if let Some(project_id) = project_id_opt {
-                                        ui.label(egui::RichText::new("Selected project").small().weak());
-                                        if ui.button("📂 Open Project").clicked() {
-                                            set_project_intent(ui.ctx(), "open", &project_id);
-                                            ui.close();
-                                        }
-                                        if ui.button("Update Project").clicked() {
-                                            set_project_intent(ui.ctx(), "update", &project_id);
-                                            ui.close();
-                                        }
-                                        if ui.button("Delete Project").clicked() {
-                                            set_project_intent(ui.ctx(), "delete", &project_id);
-                                            ui.close();
-                                        }
-                                        ui.separator();
-                                        if ui.button("➕ New Child Project").clicked() {
-                                            set_project_intent(ui.ctx(), "new_child", &project_id);
-                                            ui.close();
-                                        }
-                                    }
-
-                                    if ui.button("➕ New Project").clicked() {
-                                        set_project_intent(ui.ctx(), "new", "");
+                            if is_release_node {
+                                if let Some(sel) = sel_id {
+                                    ui.label(egui::RichText::new("Selected release").small().weak());
+                                    if ui.button("📂 Open release folder").clicked() {
+                                        // Intent carries the full "proj_X:rev:rev_01" id so the
+                                        // dispatcher can look up the release by tag.
+                                        set_project_intent(ui.ctx(), "open_release", &sel);
                                         ui.close();
                                     }
-                                })
-                                .show(ui, |builder| {
-                                    // Get root projects
-                                    let root_projects: Vec<_> = manager_state.project_list
-                                        .iter()
-                                        .filter(|p| p.parent_id.is_none())
-                                        .collect();
-
-                                    for project in root_projects {
-                                        show_tree_node_builder(
-                                            builder,
-                                            project,
-                                            &tree_structure,
-                                            &projects_by_id,
-                                            &current_project_id,
-                                            &selected_project_id,
-                                            &manager_state.project_hierarchies,
-                                        );
+                                    if ui.button("🔄 Regenerate Release").clicked() {
+                                        set_project_intent(ui.ctx(), "regen_release", &sel);
+                                        ui.close();
                                     }
-                                });
-
-                            // Handle tree view actions
-                            for action in actions {
-                                match action {
-                                    Action::SetSelected(selected_ids) => {
-                                        if let Some(first_id) = selected_ids.first() {
-                                            // Extract the actual project ID (handles file nodes like "proj_123:sheet_0")
-                                            let project_id = if first_id.contains(':') {
-                                                first_id.split(':').next().unwrap_or(first_id).to_string()
-                                            } else {
-                                                first_id.clone()
-                                            };
-                                            // Set selected project
-                                            manager_state.selected_project_id = Some(project_id);
-                                        }
-                                    }
-                                    _ => {}
+                                }
+                            } else if let Some(project_id) = project_id_opt {
+                                ui.label(egui::RichText::new("Selected project").small().weak());
+                                if ui.button("📂 Open Project").clicked() {
+                                    set_project_intent(ui.ctx(), "open", &project_id);
+                                    ui.close();
+                                }
+                                if ui.button("✎ Update Project…").clicked() {
+                                    set_project_intent(ui.ctx(), "update", &project_id);
+                                    ui.close();
+                                }
+                                if ui.button("🗑 Delete Project").clicked() {
+                                    set_project_intent(ui.ctx(), "delete", &project_id);
+                                    ui.close();
+                                }
+                                ui.separator();
+                                if ui.button("➕ New Child Project").clicked() {
+                                    set_project_intent(ui.ctx(), "new_child", &project_id);
+                                    ui.close();
                                 }
                             }
+                        })
+                        .show(ui, |builder| {
+                            let root_projects: Vec<_> = manager_state.project_list
+                                .iter()
+                                .filter(|p| p.parent_id.is_none())
+                                .collect();
+                            for project in root_projects {
+                                show_tree_node_builder(
+                                    builder,
+                                    project,
+                                    &tree_structure,
+                                    &projects_by_id,
+                                    &current_project_id,
+                                    &selected_project_id,
+                                    &manager_state.project_hierarchies,
+                                    &manager_state.project_releases,
+                                );
+                            }
                         });
-                });
 
-                // Right column: Project details
-                columns[1].vertical(|ui| {
-                    ui.heading("Project Details");
-                    ui.separator();
-
-                    if let Some(ref selected_id) = manager_state.selected_project_id {
-                        if let Some(project) = manager_state.project_list.iter().find(|p| &p.id == selected_id) {
-                            // Check if we've already warned about missing pedigree for this project
-                            let warned_id = egui::Id::new(format!("pedigree_warned_{}", selected_id));
-                            let already_warned = ui.ctx().memory(|mem| {
-                                mem.data.get_temp::<bool>(warned_id).unwrap_or(false)
-                            });
-
-                            // Try to read metadata from .kicad_pro file
-                            let kicad_metadata = crate::project_manager::kicad_metadata::get_kicad_pro_path(&project.pcb_file_path)
-                                .and_then(|pro_path| {
-                                    if pro_path.exists() {
-                                        match crate::project_manager::kicad_metadata::read_kicad_metadata(&pro_path) {
-                                            Ok(metadata) => {
-                                                // Check for missing pedigree fields - only warn once per project
-                                                if !already_warned {
-                                                    let mut missing_fields = Vec::new();
-                                                    if metadata.author.is_none() {
-                                                        missing_fields.push("Author");
-                                                    }
-                                                    if metadata.company.is_none() {
-                                                        missing_fields.push("Company");
-                                                    }
-
-                                                    if !missing_fields.is_empty() {
-                                                        logger.log_warning(&format!("Missing pedigree information in .kicad_pro: {}", missing_fields.join(", ")));
-                                                        // Mark as warned
-                                                        ui.ctx().memory_mut(|mem| {
-                                                            mem.data.insert_temp(warned_id, true);
-                                                        });
-                                                    }
-                                                }
-
-                                                Some(metadata)
-                                            }
-                                            Err(_) => None
-                                        }
-                                    } else {
-                                        None
+                    for action in actions {
+                        match action {
+                            Action::SetSelected(selected_ids) => {
+                                if let Some(first_id) = selected_ids.first() {
+                                    let project_id = first_id.split_once(':')
+                                        .map(|(head, _)| head.to_string())
+                                        .unwrap_or_else(|| first_id.clone());
+                                    manager_state.selected_project_id = Some(project_id);
+                                }
+                            }
+                            Action::Activate(activate) => {
+                                // Double-click on a project node → load.
+                                // Activate.selected is Vec<NodeId>; NodeId is String here.
+                                if let Some(first_id) = activate.selected.first() {
+                                    let project_id = first_id.split_once(':')
+                                        .map(|(head, _)| head.to_string())
+                                        .unwrap_or_else(|| first_id.clone());
+                                    // Only trigger "open" if this is actually a known project id
+                                    // (ignore activation attempts on file/rev nodes).
+                                    if manager_state.project_list.iter().any(|p| p.id == project_id) {
+                                        set_project_intent(ui.ctx(), "open", &project_id);
                                     }
-                                });
-
-                            egui::ScrollArea::vertical()
-                                .auto_shrink([false, false])
-                                .show(ui, |ui| {
-                                    // Project metadata
-                                    // Editable fields stored in memory
-                                    let name_id = egui::Id::new(format!("edit_name_{}", selected_id));
-                                    let tags_id = egui::Id::new(format!("edit_tags_{}", selected_id));
-
-                                    let mut temp_name = ui.ctx().memory(|mem| {
-                                        mem.data.get_temp::<String>(name_id)
-                                            .unwrap_or_else(|| project.name.clone())
-                                    });
-
-                                    let mut temp_tags = ui.ctx().memory(|mem| {
-                                        mem.data.get_temp::<String>(tags_id)
-                                            .unwrap_or_else(|| project.tags.join(", "))
-                                    });
-
-                                    egui::Grid::new("project_details_grid")
-                                        .num_columns(2)
-                                        .spacing([10.0, 5.0])
-                                        .striped(true)
-                                        .show(ui, |ui| {
-                                            ui.label(egui::RichText::new("Name:").strong());
-                                            ui.text_edit_singleline(&mut temp_name);
-                                            ui.end_row();
-
-                                            // Show Author from .kicad_pro if available
-                                            if let Some(ref metadata) = kicad_metadata {
-                                                if let Some(ref author) = metadata.author {
-                                                    ui.label(egui::RichText::new("Author:").strong());
-                                                    ui.label(author);
-                                                    ui.end_row();
-                                                }
-
-                                                if let Some(ref company) = metadata.company {
-                                                    ui.label(egui::RichText::new("Company:").strong());
-                                                    ui.label(company);
-                                                    ui.end_row();
-                                                }
-                                            }
-
-                                            ui.label(egui::RichText::new("Created:").strong());
-                                            ui.label(project.created_at.format("%Y-%m-%d %H:%M").to_string());
-                                            ui.end_row();
-
-                                            ui.label(egui::RichText::new("Last Modified:").strong());
-                                            ui.label(project.last_modified.format("%Y-%m-%d %H:%M").to_string());
-                                            ui.end_row();
-
-                                            // Show date from .kicad_pro if available
-                                            if let Some(ref metadata) = kicad_metadata {
-                                                if let Some(ref date) = metadata.date {
-                                                    ui.label(egui::RichText::new("Project Date:").strong());
-                                                    ui.label(date);
-                                                    ui.end_row();
-                                                }
-                                            }
-
-                                            ui.label(egui::RichText::new("Tags:").strong());
-                                            ui.text_edit_singleline(&mut temp_tags);
-                                            ui.end_row();
-                                        });
-
-                                    // Store edited values back to memory
-                                    ui.ctx().memory_mut(|mem| {
-                                        mem.data.insert_temp(name_id, temp_name.clone());
-                                        mem.data.insert_temp(tags_id, temp_tags.clone());
-                                    });
-
-                                    ui.add_space(15.0);
-
-                                    // Description section
-                                    ui.separator();
-                                    ui.label(egui::RichText::new("Description").strong().size(14.0));
-                                    ui.add_space(5.0);
-
-                                    // Get available height for description area (fill remaining space)
-                                    let available_height = ui.available_height() - 80.0; // Leave room for buttons
-
-                                    egui::Frame::NONE
-                                        .fill(ui.visuals().extreme_bg_color)
-                                        .stroke(ui.visuals().widgets.noninteractive.bg_stroke)
-                                        .inner_margin(egui::Margin::same(10))
-                                        .show(ui, |ui| {
-                                            ui.set_height(available_height.max(200.0));
-
-                                            // Use description from .kicad_pro if available, otherwise from database
-                                            let source_description = kicad_metadata.as_ref()
-                                                .and_then(|m| m.description.clone())
-                                                .unwrap_or_else(|| project.description.clone());
-
-                                            // Get or initialize the description buffer for this project
-                                            let description_id = egui::Id::new(format!("description_buffer_{}", selected_id));
-                                            let init_id = egui::Id::new(format!("description_initialized_{}", selected_id));
-
-                                            let mut temp_description = ui.ctx().memory_mut(|mem| {
-                                                // Check if we've initialized this project's description
-                                                let initialized = mem.data.get_temp::<bool>(init_id).unwrap_or(false);
-
-                                                if !initialized {
-                                                    // First time - initialize from source
-                                                    mem.data.insert_temp(init_id, true);
-                                                    mem.data.insert_temp(description_id, source_description.clone());
-                                                    source_description.clone()
-                                                } else {
-                                                    // Already initialized - use stored value
-                                                    mem.data.get_temp::<String>(description_id)
-                                                        .unwrap_or_else(|| source_description.clone())
-                                                }
-                                            });
-
-                                            // Create terminal-style text area (like Vescript FPGA Manager)
-                                            let text_edit_id = egui::Id::new(format!("description_edit_{}", selected_id));
-
-                                            let output = egui::TextEdit::multiline(&mut temp_description)
-                                                .id(text_edit_id)
-                                                .text_color(egui::Color32::GREEN)
-                                                .font(egui::TextStyle::Monospace)
-                                                .interactive(true)
-                                                .desired_rows(15)
-                                                .desired_width(f32::INFINITY)
-                                                .hint_text("Enter project description...")
-                                                .frame(false)  // Remove the frame/border
-                                                .show(ui);
-
-                                            // Store the current text in memory
-                                            ui.ctx().memory_mut(|mem| {
-                                                mem.data.insert_temp(description_id, temp_description.clone());
-                                            });
-
-                                            let response = output.response;
-
-                                            // Only save on focus lost (not on every keystroke)
-                                            if response.lost_focus() && temp_description != source_description {
-                                                ui.ctx().memory_mut(|mem| {
-                                                    mem.data.insert_temp(
-                                                        egui::Id::new("edit_description"),
-                                                        (selected_id.clone(), temp_description.clone())
-                                                    );
-                                                });
-                                            }
-                                        });
-
-                                    ui.add_space(15.0);
-
-                                    // Action buttons
-                                    ui.horizontal(|ui| {
-                                        if ui.button("📂 Load Project").clicked() {
-                                            ui.ctx().memory_mut(|mem| {
-                                                mem.data.insert_temp(egui::Id::new("load_project"), selected_id.clone());
-                                            });
-                                        }
-
-                                        if ui.button("💾 Save Project").clicked() {
-                                            ui.ctx().memory_mut(|mem| {
-                                                mem.data.insert_temp(egui::Id::new("save_project"), (selected_id.clone(), temp_name.clone(), temp_tags.clone()));
-                                            });
-                                        }
-
-                                        if ui.button("🗑️ Delete Project").clicked() {
-                                            manager_state.show_delete_confirmation = Some(selected_id.clone());
-                                        }
-                                    });
-                                });
+                                }
+                            }
+                            _ => {}
                         }
-                    } else {
-                        ui.vertical_centered(|ui| {
-                            ui.add_space(50.0);
-                            ui.label("Select a project to view details");
-                        });
                     }
                 });
-            });
+
         }
 
         // Dispatch right-click context menu intent
@@ -470,10 +257,34 @@ pub fn show_projects_panel<'a>(
                     });
                 }
                 "update" => {
-                    // Select the project — right-hand details panel already
-                    // exposes the editable fields + Save button.
+                    // Open the project-edit modal (rendered in app.rs).
+                    // The dispatcher up in app.rs/update() picks this up via
+                    // memory key "open_project_edit_modal".
                     manager_state.selected_project_id = Some(project_id.clone());
-                    logger.log_info("Edit project fields in the right panel, then click Save Project.");
+                    ui.ctx().memory_mut(|mem| {
+                        mem.data.insert_temp(
+                            egui::Id::new("open_project_edit_modal"),
+                            project_id.clone(),
+                        );
+                    });
+                }
+                "open_release" => {
+                    // project_id here is actually "proj_X:rev:rev_01".
+                    ui.ctx().memory_mut(|mem| {
+                        mem.data.insert_temp(
+                            egui::Id::new("open_release_intent"),
+                            project_id.clone(),
+                        );
+                    });
+                }
+                "regen_release" => {
+                    // Handed off to the Gerber Viewer ribbon's open_regenerate_release_modal.
+                    ui.ctx().memory_mut(|mem| {
+                        mem.data.insert_temp(
+                            egui::Id::new("regen_release_intent"),
+                            project_id.clone(),
+                        );
+                    });
                 }
                 "delete" => {
                     manager_state.show_delete_confirmation = Some(project_id.clone());
@@ -492,94 +303,9 @@ pub fn show_projects_panel<'a>(
             }
         }
 
-        // Handle save project action (name, tags, description)
-        let save_info = ui.ctx().memory(|mem| {
-            mem.data.get_temp::<(String, String, String)>(egui::Id::new("save_project"))
-        });
-
-        if let Some((project_id, new_name, new_tags_str)) = save_info {
-            ui.ctx().memory_mut(|mem| {
-                mem.data.remove::<(String, String, String)>(egui::Id::new("save_project"));
-            });
-
-            // Parse tags
-            let new_tags: Vec<String> = new_tags_str
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
-
-            // Get the current description from memory — must match the key used
-            // when writing the edit buffer above (description_buffer_{id}).
-            let description_id = egui::Id::new(format!("description_buffer_{}", project_id));
-            let new_description = ui.ctx().memory(|mem| {
-                mem.data.get_temp::<String>(description_id)
-                    .unwrap_or_else(|| {
-                        manager_state.project_list.iter()
-                            .find(|p| p.id == project_id)
-                            .map(|p| p.description.clone())
-                            .unwrap_or_default()
-                    })
-            });
-
-            if let Err(e) = manager_state.update_project(&project_id, new_name.clone(), new_description.clone(), new_tags.clone()) {
-                manager_state.last_error = Some(format!("Failed to save project: {}", e));
-            } else {
-                logger.log_info(&format!("Saved project: {}", new_name));
-
-                // Try to update the .kicad_pro file if it exists
-                if let Some(project) = manager_state.project_list.iter().find(|p| p.id == project_id) {
-                    let kicad_pro_path = crate::project_manager::kicad_metadata::get_kicad_pro_path(&project.pcb_file_path);
-                    if let Some(pro_path) = kicad_pro_path {
-                        if pro_path.exists() {
-                            // Try to update the description in the .kicad_pro file
-                            if let Err(e) = update_kicad_description(&pro_path, &new_description) {
-                                logger.log_warning(&format!("Could not update .kicad_pro description: {}", e));
-                            } else {
-                                logger.log_info("Updated description in .kicad_pro file");
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Handle description edit action (legacy - now handled by save_project)
-        let edit_info = ui.ctx().memory(|mem| {
-            mem.data.get_temp::<(String, String)>(egui::Id::new("edit_description"))
-        });
-
-        if let Some((project_id, new_description)) = edit_info {
-            ui.ctx().memory_mut(|mem| {
-                mem.data.remove::<(String, String)>(egui::Id::new("edit_description"));
-            });
-
-            // Update the project description in the database
-            if let Some(project) = manager_state.project_list.iter().find(|p| p.id == project_id) {
-                let tags = project.tags.clone();
-                let name = project.name.clone();
-                let pcb_file_path = project.pcb_file_path.clone();
-
-                if let Err(e) = manager_state.update_project(&project_id, name.clone(), new_description.clone(), tags) {
-                    manager_state.last_error = Some(format!("Failed to update description: {}", e));
-                } else {
-                    logger.log_info(&format!("Updated description for project: {}", name));
-
-                    // Also try to update the .kicad_pro file if it exists
-                    let kicad_pro_path = crate::project_manager::kicad_metadata::get_kicad_pro_path(&pcb_file_path);
-                    if let Some(pro_path) = kicad_pro_path {
-                        if pro_path.exists() {
-                            // Try to update the description in the .kicad_pro file
-                            if let Err(e) = update_kicad_description(&pro_path, &new_description) {
-                                logger.log_warning(&format!("Could not update .kicad_pro description: {}", e));
-                            } else {
-                                logger.log_info("Updated description in .kicad_pro file");
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        // (save_project and edit_description memory-key handlers removed —
+        // the Project Edit modal in app.rs now owns the save path and calls
+        // manager_state.update_project() + update_kicad_description() directly.)
 
         // Handle delete confirmation
         if let Some(ref project_id) = manager_state.show_delete_confirmation {
@@ -678,8 +404,9 @@ pub fn show_projects_panel<'a>(
     }
 }
 
-/// Helper function to update description in .kicad_pro file
-fn update_kicad_description(kicad_pro_path: &std::path::Path, new_description: &str) -> Result<(), Box<dyn std::error::Error>> {
+/// Helper function to update description in .kicad_pro file.
+/// Called by the Project Edit modal (app.rs) on Save.
+pub fn update_kicad_description(kicad_pro_path: &std::path::Path, new_description: &str) -> Result<(), Box<dyn std::error::Error>> {
     use serde_json::Value;
 
     // Read the existing .kicad_pro file
@@ -733,7 +460,9 @@ fn build_tree_structure(projects: &[ProjectMetadata]) -> HashMap<String, TreeNod
     tree
 }
 
-/// Recursively show tree nodes using builder pattern
+/// Recursively show tree nodes using builder pattern.
+/// Project nodes are `activatable(true)` so double-click → Load.
+/// Under each project: schematic → sheets, pcb, and `outputs/` with rev leaves.
 fn show_tree_node_builder(
     builder: &mut egui_ltreeview::TreeViewBuilder<String>,
     project: &ProjectMetadata,
@@ -742,6 +471,7 @@ fn show_tree_node_builder(
     current_project_id: &Option<String>,
     selected_project_id: &Option<String>,
     project_hierarchies: &HashMap<String, crate::project_manager::kicad_hierarchy::ProjectHierarchy>,
+    project_releases: &HashMap<String, Vec<crate::release::Release>>,
 ) {
     let is_current = current_project_id
         .as_ref()
@@ -753,13 +483,11 @@ fn show_tree_node_builder(
         .map(|id| id == &project.id)
         .unwrap_or(false);
 
-    // Get directory path
     let dir_path = project.pcb_file_path
         .parent()
         .and_then(|p| p.to_str())
         .unwrap_or("");
 
-    // Create label with path if selected
     let label_text = if is_selected && !dir_path.is_empty() {
         format!("{} ({})", project.name, dir_path)
     } else {
@@ -772,23 +500,33 @@ fn show_tree_node_builder(
         egui::RichText::new(&label_text)
     };
 
-    // Check if this project has child projects
     let has_child_projects = tree_structure
         .get(&project.id)
         .map(|node| !node.children.is_empty())
         .unwrap_or(false);
 
-    // Check if we have KiCad hierarchy for this project
     let has_kicad_hierarchy = project_hierarchies
         .get(&project.id)
         .map(|h| h.root_schematic.is_some() || h.pcb_file.is_some() || !h.sheets.is_empty())
         .unwrap_or(false);
 
-    // Show as directory if it has children or KiCad files
-    if has_child_projects || has_kicad_hierarchy {
-        builder.dir(project.id.clone(), label);
+    let has_releases = project_releases
+        .get(&project.id)
+        .map(|r| !r.is_empty())
+        .unwrap_or(false);
 
-        // Show child projects first
+    // Project row is always rendered as a directory if it has any children to
+    // expand, otherwise as an activatable leaf.
+    let has_any_children = has_child_projects || has_kicad_hierarchy || has_releases;
+
+    if has_any_children {
+        builder.node(
+            NodeBuilder::dir(project.id.clone())
+                .label(label)
+                .activatable(true),
+        );
+
+        // Child projects first (by parent_id hierarchy).
         if let Some(node) = tree_structure.get(&project.id) {
             for child_id in &node.children {
                 if let Some(child_project) = projects_by_id.get(child_id) {
@@ -800,44 +538,53 @@ fn show_tree_node_builder(
                         current_project_id,
                         selected_project_id,
                         project_hierarchies,
+                        project_releases,
                     );
                 }
             }
         }
 
-        // Show KiCad hierarchy files
+        // KiCad files: schematic (+ sheets) and pcb.
         if let Some(hierarchy) = project_hierarchies.get(&project.id) {
-            // Show root schematic with sub-sheets as children
             if let Some(ref root_sch) = hierarchy.root_schematic {
                 let file_name = root_sch.file_name().and_then(|f| f.to_str()).unwrap_or("Unknown");
-
-                // If there are sub-sheets, show root schematic as expandable directory
                 if !hierarchy.sheets.is_empty() {
                     builder.dir(format!("{}:sch_root", project.id), egui::RichText::new(format!("📄 {}", file_name)));
-
-                    // Show hierarchical sheets as children of root schematic
                     for (idx, sheet) in hierarchy.sheets.iter().enumerate() {
                         show_hierarchical_sheet_node(builder, sheet, &format!("{}:sheet_{}", project.id, idx));
                     }
-
                     builder.close_dir();
                 } else {
-                    // No sub-sheets, just show as leaf
                     builder.leaf(format!("{}:sch_root", project.id), egui::RichText::new(format!("📄 {}", file_name)));
                 }
             }
-
-            // Show PCB file
             if let Some(ref pcb) = hierarchy.pcb_file {
                 let file_name = pcb.file_name().and_then(|f| f.to_str()).unwrap_or("Unknown");
                 builder.leaf(format!("{}:pcb", project.id), egui::RichText::new(format!("🔧 {}", file_name)));
             }
         }
 
+        // outputs/ subtree — one leaf per release.
+        if has_releases {
+            builder.dir(format!("{}:outputs", project.id), egui::RichText::new("📁 outputs"));
+            if let Some(releases) = project_releases.get(&project.id) {
+                for rel in releases {
+                    builder.leaf(
+                        format!("{}:rev:{}", project.id, rel.tag),
+                        egui::RichText::new(format!("📦 {}", rel.tag)),
+                    );
+                }
+            }
+            builder.close_dir();
+        }
+
         builder.close_dir();
     } else {
-        // Leaf node (no children, no KiCad hierarchy)
-        builder.leaf(project.id.clone(), label);
+        builder.node(
+            NodeBuilder::leaf(project.id.clone())
+                .label(label)
+                .activatable(true),
+        );
     }
 }
 

--- a/crates/copperforge-core/src/ui/settings_panel.rs
+++ b/crates/copperforge-core/src/ui/settings_panel.rs
@@ -193,36 +193,9 @@ pub fn show_settings_panel<'a>(
 
     ui.add_space(20.0);
 
-    // Library Configuration Section
-    ui.group(|ui| {
-        ui.label("KiCad Library Configuration");
-        ui.label(egui::RichText::new("💡 These settings apply when creating new KiCad projects").small().italics());
-        ui.separator();
-
-        // Initialize project manager state if needed to access library settings
-        if app.project_manager_state.is_none() {
-            let mut state = crate::project_manager::ProjectManagerState::with_config(&app.services.config);
-            let db_path = app.services.config_path.join("projects.db");
-            let _ = state.initialize_database(&db_path);
-            app.project_manager_state = Some(state);
-        }
-
-        if let Some(ref mut manager_state) = app.project_manager_state {
-            ui.checkbox(&mut manager_state.include_kiverse, "Include KiVerse Symbol Library");
-            ui.checkbox(&mut manager_state.include_atlantix_resistors, "Include Atlantix-EDA Resistor Library");
-
-            ui.add_space(5.0);
-
-            ui.label("KiVerse Library Path:");
-            ui.horizontal(|ui| {
-                let kiverse_text = manager_state.kiverse_path.display().to_string();
-                ui.label(egui::RichText::new(&kiverse_text).small().monospace());
-            });
-            ui.label(egui::RichText::new("Default: ~/kiverse").small().italics());
-        }
-    });
-
-    ui.add_space(20.0);
+    // (KiCad library configuration moved to ProjectConfig defaults — edit via
+    // the Shell `new-project` command flags or ~/.config/copperforge/
+    // project_config.json directly.)
 
     // Language Section (placeholder for future)
     ui.group(|ui| {

--- a/crates/copperforge-core/src/ui/settings_panel.rs
+++ b/crates/copperforge-core/src/ui/settings_panel.rs
@@ -22,17 +22,17 @@ pub fn show_settings_panel<'a>(
             ui.label("Global Units:");
             
             // Get current units from layer store
-            let _current_unit = app.layer_store.units.display_unit;
+            let _current_unit = app.services.layer_store.units.display_unit;
             
             // Track if units changed
             let mut units_changed = false;
-            let prev_units = app.global_units_mils;
+            let prev_units = app.services.global_units_mils;
             
             // Update legacy global_units_mils based on selection
-            if ui.selectable_value(&mut app.global_units_mils, false, "Millimeters (mm)").clicked() {
+            if ui.selectable_value(&mut app.services.global_units_mils, false, "Millimeters (mm)").clicked() {
                 units_changed = true;
             }
-            if ui.selectable_value(&mut app.global_units_mils, true, "Mils (1/1000 inch)").clicked() {
+            if ui.selectable_value(&mut app.services.global_units_mils, true, "Mils (1/1000 inch)").clicked() {
                 units_changed = true;
             }
             
@@ -40,11 +40,11 @@ pub fn show_settings_panel<'a>(
             ui.add_enabled(false, egui::Button::new("Micrometers (µm)"));
             ui.add_enabled(false, egui::Button::new("Nanometers (nm)"));
             
-            if units_changed || prev_units != app.global_units_mils {
+            if units_changed || prev_units != app.services.global_units_mils {
                 // Sync to ECS
                 app.sync_units_to_ecs();
                 
-                let units_name = if app.global_units_mils { "mils" } else { "mm" };
+                let units_name = if app.services.global_units_mils { "mils" } else { "mm" };
                 logger.log_info(&format!("Changed global units to {}", units_name));
             }
         });
@@ -61,7 +61,7 @@ pub fn show_settings_panel<'a>(
             ui.label("Timezone:");
             
             // Get current timezone name or use UTC as default
-            let current_tz_name = app.user_timezone.as_ref()
+            let current_tz_name = app.services.user_timezone.as_ref()
                 .map(|s| s.as_str())
                 .unwrap_or("UTC");
             
@@ -84,7 +84,7 @@ pub fn show_settings_panel<'a>(
                         "Asia/Shanghai",
                         "Australia/Sydney",
                     ] {
-                        if ui.selectable_value(&mut app.user_timezone, Some(tz_name.to_string()), *tz_name).clicked() {
+                        if ui.selectable_value(&mut app.services.user_timezone, Some(tz_name.to_string()), *tz_name).clicked() {
                             logger.log_info(&format!("Changed timezone to {}", tz_name));
                         }
                     }
@@ -95,7 +95,7 @@ pub fn show_settings_panel<'a>(
                     // All timezones
                     for tz in chrono_tz::TZ_VARIANTS {
                         let tz_name = tz.name();
-                        if ui.selectable_value(&mut app.user_timezone, Some(tz_name.to_string()), tz_name).clicked() {
+                        if ui.selectable_value(&mut app.services.user_timezone, Some(tz_name.to_string()), tz_name).clicked() {
                             logger.log_info(&format!("Changed timezone to {}", tz_name));
                         }
                     }
@@ -107,27 +107,27 @@ pub fn show_settings_panel<'a>(
         // Clock format selection
         ui.horizontal(|ui| {
             ui.label("Clock Format:");
-            let prev_format = app.use_24_hour_clock;
-            ui.selectable_value(&mut app.use_24_hour_clock, true, "24-hour (13:30:45)");
-            ui.selectable_value(&mut app.use_24_hour_clock, false, "12-hour (1:30:45 PM)");
+            let prev_format = app.services.use_24_hour_clock;
+            ui.selectable_value(&mut app.services.use_24_hour_clock, true, "24-hour (13:30:45)");
+            ui.selectable_value(&mut app.services.use_24_hour_clock, false, "12-hour (1:30:45 PM)");
             
-            if prev_format != app.use_24_hour_clock {
-                let format_name = if app.use_24_hour_clock { "24-hour" } else { "12-hour" };
+            if prev_format != app.services.use_24_hour_clock {
+                let format_name = if app.services.use_24_hour_clock { "24-hour" } else { "12-hour" };
                 logger.log_info(&format!("Changed clock format to {}", format_name));
             }
         });
         
         // Show current time in selected timezone with chosen format
-        let time_format = if app.use_24_hour_clock { "%Y-%m-%d %H:%M:%S %Z" } else { "%Y-%m-%d %I:%M:%S %p %Z" };
+        let time_format = if app.services.use_24_hour_clock { "%Y-%m-%d %H:%M:%S %Z" } else { "%Y-%m-%d %I:%M:%S %p %Z" };
         
-        if let Some(tz_name) = &app.user_timezone {
+        if let Some(tz_name) = &app.services.user_timezone {
             if let Ok(tz) = tz_name.parse::<Tz>() {
                 let now = Local::now().with_timezone(&tz);
                 ui.label(format!("Current time: {}", now.format(time_format)));
             }
         } else {
             let now = Local::now();
-            ui.label(format!("Current time: {}", now.format(if app.use_24_hour_clock { "%Y-%m-%d %H:%M:%S" } else { "%Y-%m-%d %I:%M:%S %p" })));
+            ui.label(format!("Current time: {}", now.format(if app.services.use_24_hour_clock { "%Y-%m-%d %H:%M:%S" } else { "%Y-%m-%d %I:%M:%S %p" })));
         }
     });
     
@@ -142,7 +142,7 @@ pub fn show_settings_panel<'a>(
             ui.label("Preferred PCB Projects Directory:");
         });
 
-        let current_dir_text = if let Some(ref dir) = app.project_manager.config.preferred_projects_directory {
+        let current_dir_text = if let Some(ref dir) = app.services.config.preferred_projects_directory {
             dir.display().to_string()
         } else {
             "Not set (will use home directory)".to_string()
@@ -156,7 +156,7 @@ pub fn show_settings_panel<'a>(
 
                 // Set initial directory to current preference if available
                 let dialog = mem::replace(&mut app.projects_directory_dialog, egui_file_dialog::FileDialog::new());
-                app.projects_directory_dialog = if let Some(ref current_dir) = app.project_manager.config.preferred_projects_directory {
+                app.projects_directory_dialog = if let Some(ref current_dir) = app.services.config.preferred_projects_directory {
                     dialog.initial_directory(current_dir.clone())
                 } else {
                     dialog
@@ -164,9 +164,9 @@ pub fn show_settings_panel<'a>(
                 app.projects_directory_dialog.pick_directory();
             }
 
-            if app.project_manager.config.preferred_projects_directory.is_some() {
+            if app.services.config.preferred_projects_directory.is_some() {
                 if ui.button("Clear").clicked() {
-                    app.project_manager.config.preferred_projects_directory = None;
+                    app.services.config.preferred_projects_directory = None;
                     app.save_settings();
                     logger.log_info("Cleared preferred projects directory");
                 }
@@ -182,7 +182,7 @@ pub fn show_settings_panel<'a>(
             if should_process {
                 app.last_picked_projects_directory = Some(path.clone());
                 let path_display = path.display().to_string();
-                app.project_manager.config.preferred_projects_directory = Some(path);
+                app.services.config.preferred_projects_directory = Some(path);
                 app.save_settings();
                 logger.log_info(&format!("Set preferred projects directory to: {}", path_display));
             }
@@ -201,8 +201,8 @@ pub fn show_settings_panel<'a>(
 
         // Initialize project manager state if needed to access library settings
         if app.project_manager_state.is_none() {
-            let mut state = crate::project_manager::ProjectManagerState::with_config(&app.project_manager.config);
-            let db_path = app.config_path.join("projects.db");
+            let mut state = crate::project_manager::ProjectManagerState::with_config(&app.services.config);
+            let db_path = app.services.config_path.join("projects.db");
             let _ = state.initialize_database(&db_path);
             app.project_manager_state = Some(state);
         }

--- a/crates/copperforge-core/src/ui/tabs.rs
+++ b/crates/copperforge-core/src/ui/tabs.rs
@@ -122,16 +122,13 @@ impl Tab {
                 self.render_gerber_view(ui, params.app);
             }
             TabKind::Logger => {
-                LoggerPanel::new(egui_citizen::CitizenState::default())
-                    .show(ui, params.app);
+                params.app.logger_panel.show(ui, &mut params.app.services);
             }
             TabKind::Terminal => {
-                TerminalPanel::new(egui_citizen::CitizenState::default())
-                    .show(ui, params.app);
+                params.app.terminal_panel.show(ui, &mut params.app.services);
             }
             TabKind::Shell => {
-                ShellPanel::new(egui_citizen::CitizenState::default())
-                    .show(ui, params.app);
+                params.app.shell_panel.show(ui, &mut params.app.services);
             }
             TabKind::Project => {
                 ProjectPanel::new(egui_citizen::CitizenState::default())
@@ -146,8 +143,7 @@ impl Tab {
                     .show(ui, params.app);
             }
             TabKind::BOM => {
-                BomPanel::new(egui_citizen::CitizenState::default())
-                    .show(ui, params.app);
+                params.app.bom_panel.show(ui, &mut params.app.services);
             }
         }
     }

--- a/crates/copperforge-core/src/ui/tabs.rs
+++ b/crates/copperforge-core/src/ui/tabs.rs
@@ -250,11 +250,13 @@ fn render_pcb_workflow_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
             app.services.project_state.get().pcb_path().map(|p| p.to_path_buf()),
             app.services.project_state.get().gerber_dir().map(|p| p.to_path_buf()),
         ) {
-            app.services.project_state.set(ProjectState::LoadingGerbers { pcb_path: pcb_path.clone(), gerber_dir: gerber_dir.clone() });            gerber_ops::load_gerbers_into_viewer(app, &gerber_dir, &logger);
+            app.services.project_state.set(ProjectState::LoadingGerbers { pcb_path: pcb_path.clone(), gerber_dir: gerber_dir.clone() });
+            gerber_ops::load_gerbers_into_viewer(app, &gerber_dir, &logger);
             let last_modified = std::fs::metadata(&pcb_path)
                 .and_then(|m| m.modified())
                 .unwrap_or(std::time::SystemTime::now());
-            app.services.project_state.set(ProjectState::Ready { pcb_path, gerber_dir, last_modified });        }
+            app.services.project_state.set(ProjectState::Ready { pcb_path, gerber_dir, last_modified });
+        }
     }
 
     // Stale-file indicator
@@ -270,14 +272,97 @@ fn render_pcb_workflow_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
 
     ui.separator();
 
+    // Release: only enabled once gerbers are loaded AND a project record exists
+    // in the database (so the release can be persisted against a project).
+    let is_ready = matches!(app.services.project_state.get(), ProjectState::Ready { .. });
+    let has_current_project = app.project_manager_state
+        .as_ref()
+        .and_then(|s| s.current_project.as_ref())
+        .is_some();
+    let release_enabled = is_ready && has_current_project;
+
+    let release_btn = ui.add_enabled(release_enabled, egui::Button::new("🚀 Release"));
+    let release_btn = if !has_current_project && is_ready {
+        release_btn.on_disabled_hover_text("Open or create a project record in the Projects tab first.")
+    } else if !is_ready {
+        release_btn.on_disabled_hover_text("Load gerbers (Generate + Load) before cutting a release.")
+    } else {
+        release_btn
+    };
+    if release_btn.clicked() {
+        open_release_modal(app);
+    }
+
+    // Pick up a pending "regenerate-release" intent from the Projects tab
+    // (set by right-click → Regenerate on a rev node). We open the release
+    // modal pre-filled with the existing rev's fields + overwrite flag.
+    let regen_tag = ui.ctx().memory(|mem| {
+        mem.data.get_temp::<String>(egui::Id::new("regen_release_intent"))
+    });
+    if let Some(composite) = regen_tag {
+        ui.ctx().memory_mut(|mem| {
+            mem.data.remove::<String>(egui::Id::new("regen_release_intent"));
+        });
+        open_regenerate_release_modal(app, &composite);
+    }
+
+    ui.separator();
+
     if ui.add_enabled(has_pcb, egui::Button::new("✖ Clear")).clicked() {
-        app.services.project_state.set(ProjectState::NoProject);        if let Some(ref mut manager_state) = app.project_manager_state {
+        app.services.project_state.set(ProjectState::NoProject);
+        if let Some(ref mut manager_state) = app.project_manager_state {
             manager_state.current_project = None;
             manager_state.selected_project_id = None;
         }
         app.services.layer_store.clear_all();
         logger.log_info("Cleared PCB file selection");
     }
+}
+
+/// Seed the release modal with sensible defaults: next rev tag + current
+/// project description prefilled.
+fn open_release_modal(app: &mut CopperForgeApp) {
+    let (existing_releases, description_prefill) = app.project_manager_state
+        .as_ref()
+        .and_then(|s| s.current_project.as_ref())
+        .map(|p| (p.releases.clone(), p.metadata.description.clone()))
+        .unwrap_or_default();
+    let suggested_tag = crate::release::suggest_next_rev_tag(&existing_releases);
+    app.release_modal = Some(crate::app::ReleaseModalState {
+        rev_tag: suggested_tag,
+        description: description_prefill,
+        changes: String::new(),
+        include_date_in_name: true,
+        include_notes_in_zip: true,
+        error: None,
+        overwrite_existing: false,
+    });
+}
+
+/// Open the release modal in Regenerate mode — seeded from the existing
+/// release's fields, overwrite flag set. `composite` is "proj_X:rev:rev_02".
+fn open_regenerate_release_modal(app: &mut CopperForgeApp, composite: &str) {
+    let mut parts = composite.splitn(3, ':');
+    let project_id = match parts.next() { Some(s) => s, None => return };
+    let _marker = parts.next();
+    let rev_tag = match parts.next() { Some(s) => s, None => return };
+
+    let existing = app.project_manager_state
+        .as_ref()
+        .and_then(|pm| pm.project_releases.get(project_id))
+        .and_then(|releases| releases.iter().find(|r| r.tag == rev_tag))
+        .cloned();
+    let Some(existing) = existing else { return };
+
+    app.release_modal = Some(crate::app::ReleaseModalState {
+        rev_tag: existing.tag.clone(),
+        description: existing.description.clone(),
+        changes: existing.changes.clone(),
+        include_date_in_name: existing.include_date_in_name,
+        include_notes_in_zip: existing.include_notes_in_zip,
+        error: None,
+        overwrite_existing: true,
+    });
 }
 
 fn render_quadrant_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {

--- a/crates/copperforge-core/src/ui/tabs.rs
+++ b/crates/copperforge-core/src/ui/tabs.rs
@@ -71,7 +71,7 @@ pub struct Tab {
 impl Tab {
     /// Helper to get units from app
     fn get_units(app: &CopperForgeApp) -> &crate::layer_store::UnitsState {
-        &app.layer_store.units
+        &app.services.layer_store.units
     }
     
     pub fn new(kind: TabKind, surface: SurfaceIndex, node: NodeIndex) -> Self {
@@ -202,13 +202,13 @@ fn render_pcb_workflow_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
     use crate::project::{gerber_ops, ProjectState};
 
     // Clone reactive handles up front so we can take `&mut app` later without
-    // a borrow conflict with a logger that borrows `app.logger_state`.
-    let logger_state = app.logger_state.clone();
-    let log_colors = app.log_colors.clone();
+    // a borrow conflict with a logger that borrows `app.services.logger_state`.
+    let logger_state = app.services.logger_state.clone();
+    let log_colors = app.services.log_colors.clone();
     let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
 
     // State label (dim when NoProject)
-    let (state_label, state_color) = match &app.project_manager.state {
+    let (state_label, state_color) = match &app.services.project_state.get() {
         ProjectState::NoProject => ("no PCB", egui::Color32::from_rgb(120, 120, 120)),
         ProjectState::PcbSelected { .. } => ("PCB selected", egui::Color32::from_rgb(180, 180, 220)),
         ProjectState::GeneratingGerbers { .. } => ("generating…", egui::Color32::from_rgb(230, 200, 120)),
@@ -220,55 +220,49 @@ fn render_pcb_workflow_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
 
     ui.separator();
 
-    let has_pcb = app.project_manager.state.pcb_path().is_some();
-    let has_gerber_dir = app.project_manager.state.gerber_dir().is_some();
+    let has_pcb = app.services.project_state.get().pcb_path().is_some();
+    let has_gerber_dir = app.services.project_state.get().gerber_dir().is_some();
 
     // Generate: explicit. Disabled if no PCB is selected.
     if ui.add_enabled(has_pcb, egui::Button::new("⚙ Generate Gerbers")).clicked() {
-        if let Some(pcb_path) = app.project_manager.state.pcb_path().map(|p| p.to_path_buf()) {
-            // Ensure kicad-cli discovery has run (no-op after the first probe).
-            if app.kicad_cli_command().is_none() {
-                app.detect_and_cache_kicad();
-            }
+        if let Some(pcb_path) = app.services.project_state.get().pcb_path().map(|p| p.to_path_buf()) {
             let Some(cli) = app.kicad_cli_command() else {
-                logger.log_error("kicad-cli not found (checked PATH, Flatpak, and Snap)");
+                logger.log_error("kicad-cli not found (checked PATH, Flatpak, and Snap at startup)");
                 return;
             };
             logger.log_info(&format!(
                 "Generating gerbers via kicad-cli ({})…",
-                app.kicad_cli_method.as_deref().unwrap_or("?")
+                app.services.kicad_cli_method.as_deref().unwrap_or("?")
             ));
-            app.project_manager.state = ProjectState::GeneratingGerbers { pcb_path: pcb_path.clone() };
+            app.services.project_state.set(ProjectState::GeneratingGerbers { pcb_path: pcb_path.clone() });
             if let Some(output_dir) = gerber_ops::generate_gerbers_from_pcb(&pcb_path, cli, &logger) {
-                app.project_manager.state = ProjectState::GerbersGenerated { pcb_path, gerber_dir: output_dir };
+                app.services.project_state.set(ProjectState::GerbersGenerated { pcb_path, gerber_dir: output_dir });
             } else {
-                app.project_manager.state = ProjectState::PcbSelected { pcb_path };
+                app.services.project_state.set(ProjectState::PcbSelected { pcb_path });
             }
         }
     }
 
     // Load: disabled until gerbers have been generated (or already loaded — allows Reload).
-    let load_label = if matches!(app.project_manager.state, ProjectState::Ready { .. }) {
+    let load_label = if matches!(app.services.project_state.get(), ProjectState::Ready { .. }) {
         "↻ Reload Gerbers"
     } else {
         "⬇ Load Gerbers"
     };
     if ui.add_enabled(has_gerber_dir, egui::Button::new(load_label)).clicked() {
         if let (Some(pcb_path), Some(gerber_dir)) = (
-            app.project_manager.state.pcb_path().map(|p| p.to_path_buf()),
-            app.project_manager.state.gerber_dir().map(|p| p.to_path_buf()),
+            app.services.project_state.get().pcb_path().map(|p| p.to_path_buf()),
+            app.services.project_state.get().gerber_dir().map(|p| p.to_path_buf()),
         ) {
-            app.project_manager.state = ProjectState::LoadingGerbers { pcb_path: pcb_path.clone(), gerber_dir: gerber_dir.clone() };
-            gerber_ops::load_gerbers_into_viewer(app, &gerber_dir, &logger);
+            app.services.project_state.set(ProjectState::LoadingGerbers { pcb_path: pcb_path.clone(), gerber_dir: gerber_dir.clone() });            gerber_ops::load_gerbers_into_viewer(app, &gerber_dir, &logger);
             let last_modified = std::fs::metadata(&pcb_path)
                 .and_then(|m| m.modified())
                 .unwrap_or(std::time::SystemTime::now());
-            app.project_manager.state = ProjectState::Ready { pcb_path, gerber_dir, last_modified };
-        }
+            app.services.project_state.set(ProjectState::Ready { pcb_path, gerber_dir, last_modified });        }
     }
 
     // Stale-file indicator
-    if let ProjectState::Ready { pcb_path, last_modified, .. } = &app.project_manager.state {
+    if let ProjectState::Ready { pcb_path, last_modified, .. } = &app.services.project_state.get() {
         if let Ok(meta) = std::fs::metadata(pcb_path) {
             if let Ok(modified) = meta.modified() {
                 if &modified != last_modified {
@@ -281,23 +275,22 @@ fn render_pcb_workflow_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
     ui.separator();
 
     if ui.add_enabled(has_pcb, egui::Button::new("✖ Clear")).clicked() {
-        app.project_manager.state = ProjectState::NoProject;
-        if let Some(ref mut manager_state) = app.project_manager_state {
+        app.services.project_state.set(ProjectState::NoProject);        if let Some(ref mut manager_state) = app.project_manager_state {
             manager_state.current_project = None;
             manager_state.selected_project_id = None;
         }
-        app.layer_store.clear_all();
+        app.services.layer_store.clear_all();
         logger.log_info("Cleared PCB file selection");
     }
 }
 
 fn render_quadrant_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
-    if ui.checkbox(&mut app.display_manager.quadrant_view_enabled, "Quadrant View").clicked() {
-        app.layer_store.mark_dirty();
-        app.needs_initial_view = true;
+    if ui.checkbox(&mut app.services.display_manager.quadrant_view_enabled, "Quadrant View").clicked() {
+        app.services.layer_store.mark_dirty();
+        app.services.needs_initial_view = true;
     }
     
-    if app.display_manager.quadrant_view_enabled {
+    if app.services.display_manager.quadrant_view_enabled {
         ui.separator();
         ui.label("Spacing:");
         
@@ -305,10 +298,10 @@ fn render_quadrant_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
         let units_resource = Tab::get_units(app);
         
         let (mut spacing_value, units_suffix, conversion_factor) = if units_resource.is_mils() {
-            let spacing_nm = mm_to_nm(app.display_manager.quadrant_offset_magnitude);
+            let spacing_nm = mm_to_nm(app.services.display_manager.quadrant_offset_magnitude);
             (nm_to_mils(spacing_nm) as f32, "mils", 0.0254)
         } else {
-            (app.display_manager.quadrant_offset_magnitude as f32, "mm", 1.0)
+            (app.services.display_manager.quadrant_offset_magnitude as f32, "mm", 1.0)
         };
 
         let speed = if units_resource.is_mils() { 10.0 } else { 1.0 };
@@ -321,15 +314,15 @@ fn render_quadrant_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
             .changed() 
         {
             let spacing_mm = spacing_value * conversion_factor;
-            app.display_manager.set_quadrant_offset_magnitude(spacing_mm as f64);
-            app.layer_store.mark_dirty();
+            app.services.display_manager.set_quadrant_offset_magnitude(spacing_mm as f64);
+            app.services.layer_store.mark_dirty();
         }
         
         ui.separator();
         
         if ui.button("📷 Export Layers as PNG").clicked() {
-            let logger_state = app.logger_state.clone();
-            let log_colors = app.log_colors.clone();
+            let logger_state = app.services.logger_state.clone();
+            let log_colors = app.services.log_colors.clone();
             let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
             crate::ui::orientation_panel::export_quadrant_layers_to_png(app, &logger);
         }
@@ -337,9 +330,9 @@ fn render_quadrant_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
 }
 
 fn render_layer_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
-    let flip_text = if app.display_manager.showing_top { "🔄 Flip to Bottom (F)" } else { "🔄 Flip to Top (F)" };
+    let flip_text = if app.services.display_manager.showing_top { "🔄 Flip to Bottom (F)" } else { "🔄 Flip to Top (F)" };
     if ui.button(flip_text).clicked() {
-        app.display_manager.showing_top = !app.display_manager.showing_top;
+        app.services.display_manager.showing_top = !app.services.display_manager.showing_top;
         
         // Auto-toggle layer visibility based on flip state
         use crate::layer_store::{LayerType, Side};
@@ -349,43 +342,43 @@ fn render_layer_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
                 LayerType::Silkscreen(Side::Top) |
                 LayerType::Soldermask(Side::Top) |
                 LayerType::Paste(Side::Top) => {
-                    app.display_manager.showing_top
+                    app.services.display_manager.showing_top
                 },
                 LayerType::Copper(_) => {
-                    !app.display_manager.showing_top
+                    !app.services.display_manager.showing_top
                 },
                 LayerType::Silkscreen(Side::Bottom) |
                 LayerType::Soldermask(Side::Bottom) |
                 LayerType::Paste(Side::Bottom) => {
-                    !app.display_manager.showing_top
+                    !app.services.display_manager.showing_top
                 },
                 LayerType::MechanicalOutline => {
                     // Leave outline visibility unchanged
-                    app.layer_store.get_visibility(layer_type)
+                    app.services.layer_store.get_visibility(layer_type)
                 }
             };
-            app.layer_store.set_visibility(layer_type, visible);
+            app.services.layer_store.set_visibility(layer_type, visible);
         }
         
-        app.layer_store.mark_dirty();
+        app.services.layer_store.mark_dirty();
     }
 }
 
 fn render_transform_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
     // Rotate button
     if ui.button("🔄 Rotate (R)").clicked() {
-        app.rotation_degrees = (app.rotation_degrees + 90.0) % 360.0;
+        app.services.rotation_degrees = (app.services.rotation_degrees + 90.0) % 360.0;
         
         // Don't reset view - just mark coordinates as dirty to update rotation
         // This keeps the view centered on the current origin
-        app.layer_store.mark_dirty();
+        app.services.layer_store.mark_dirty();
         
-        let logger_state = app.logger_state.clone();
-        let log_colors = app.log_colors.clone();
+        let logger_state = app.services.logger_state.clone();
+        let log_colors = app.services.log_colors.clone();
         let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
         logger.log_custom(
             crate::project::constants::LOG_TYPE_ROTATION, 
-            &format!("Rotated to {:.0}°", app.rotation_degrees)
+            &format!("Rotated to {:.0}°", app.services.rotation_degrees)
         );
     }
     
@@ -393,62 +386,62 @@ fn render_transform_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
     ui.label("🔥 Rendering (v0.2.0)");
     
     // Mirror buttons
-    let x_mirror_text = if app.display_manager.mirroring.x { "↔️ X Mirror ✓" } else { "↔️ X Mirror" };
+    let x_mirror_text = if app.services.display_manager.mirroring.x { "↔️ X Mirror ✓" } else { "↔️ X Mirror" };
     if ui.button(x_mirror_text).clicked() {
-        app.display_manager.mirroring.x = !app.display_manager.mirroring.x;
+        app.services.display_manager.mirroring.x = !app.services.display_manager.mirroring.x;
         // Don't reset custom origin, just mark coordinates as dirty
-        app.layer_store.mark_dirty();
+        app.services.layer_store.mark_dirty();
         
-        let logger_state = app.logger_state.clone();
-        let log_colors = app.log_colors.clone();
+        let logger_state = app.services.logger_state.clone();
+        let log_colors = app.services.log_colors.clone();
         let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
         logger.log_custom(
             crate::project::constants::LOG_TYPE_MIRROR,
-            &format!("X mirroring {}", if app.display_manager.mirroring.x { "enabled" } else { "disabled" })
+            &format!("X mirroring {}", if app.services.display_manager.mirroring.x { "enabled" } else { "disabled" })
         );
     }
     
-    let y_mirror_text = if app.display_manager.mirroring.y { "↕️ Y Mirror ✓" } else { "↕️ Y Mirror" };
+    let y_mirror_text = if app.services.display_manager.mirroring.y { "↕️ Y Mirror ✓" } else { "↕️ Y Mirror" };
     if ui.button(y_mirror_text).clicked() {
-        app.display_manager.mirroring.y = !app.display_manager.mirroring.y;
+        app.services.display_manager.mirroring.y = !app.services.display_manager.mirroring.y;
         // Don't reset custom origin, just mark coordinates as dirty
-        app.layer_store.mark_dirty();
+        app.services.layer_store.mark_dirty();
         
-        let logger_state = app.logger_state.clone();
-        let log_colors = app.log_colors.clone();
+        let logger_state = app.services.logger_state.clone();
+        let log_colors = app.services.log_colors.clone();
         let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
         logger.log_custom(
             crate::project::constants::LOG_TYPE_MIRROR,
-            &format!("Y mirroring {}", if app.display_manager.mirroring.y { "enabled" } else { "disabled" })
+            &format!("Y mirroring {}", if app.services.display_manager.mirroring.y { "enabled" } else { "disabled" })
         );
     }
     
     ui.separator();
     
     // Origin setting button
-    let origin_set = app.display_manager.design_offset.x != 0.0 || app.display_manager.design_offset.y != 0.0;
+    let origin_set = app.services.display_manager.design_offset.x != 0.0 || app.services.display_manager.design_offset.y != 0.0;
     if origin_set {
         if ui.button("🎯 Reset Origin").clicked() {
-            app.display_manager.design_offset = crate::display::VectorOffset { x: 0.0, y: 0.0 };
-            app.origin_has_been_set = false;
+            app.services.display_manager.design_offset = crate::display::VectorOffset { x: 0.0, y: 0.0 };
+            app.services.origin_has_been_set = false;
             
             // Force view refresh to properly center coordinates at the new origin
-            app.needs_initial_view = true;
+            app.services.needs_initial_view = true;
             
             // Mark coordinates as dirty to force refresh
-            app.layer_store.mark_dirty();
+            app.services.layer_store.mark_dirty();
             
-            let logger_state = app.logger_state.clone();
-            let log_colors = app.log_colors.clone();
+            let logger_state = app.services.logger_state.clone();
+            let log_colors = app.services.log_colors.clone();
             let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
             logger.log_info("Reset origin to (0, 0) - view recentered");
         }
     } else {
         if ui.button("🎯 Set Origin").clicked() {
-            app.setting_origin_mode = true;
+            app.services.setting_origin_mode = true;
             
-            let logger_state = app.logger_state.clone();
-            let log_colors = app.log_colors.clone();
+            let logger_state = app.services.logger_state.clone();
+            let log_colors = app.services.log_colors.clone();
             let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
             logger.log_info("Click on the PCB to set the origin");
         }
@@ -479,7 +472,7 @@ fn render_grid_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
         } else {
             spacing as f32
         };
-        if (app.grid_settings.spacing_mm - spacing_mm).abs() < 0.001 {
+        if (app.services.grid_settings.spacing_mm - spacing_mm).abs() < 0.001 {
             current_spacing_display = if is_mils {
                 format!("{} mils", spacing as i32)
             } else {
@@ -504,7 +497,7 @@ fn render_grid_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
                     format!("{:.3} mm", spacing)
                 };
                 if ui.selectable_label(false, label).clicked() {
-                    app.grid_settings.spacing_mm = spacing_mm;
+                    app.services.grid_settings.spacing_mm = spacing_mm;
                 }
             }
         });
@@ -513,30 +506,30 @@ fn render_grid_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
     
     // Grid dot size slider
     ui.label("Dot Size:");
-    ui.add(egui::Slider::new(&mut app.grid_settings.dot_size, 0.5..=5.0).suffix("px"));
+    ui.add(egui::Slider::new(&mut app.services.grid_settings.dot_size, 0.5..=5.0).suffix("px"));
     
     ui.separator();
     
     // Enterprise feature: Snap to Grid
-    ui.checkbox(&mut app.grid_settings.snap_enabled, "🧲 Snap to Grid");
+    ui.checkbox(&mut app.services.grid_settings.snap_enabled, "🧲 Snap to Grid");
 }
 
 fn render_ruler_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
     ui.label("📏 Ruler Tool:");
     
-    let ruler_button_text = if app.ruler_active { "📏 Ruler ✓" } else { "📏 Ruler" };
+    let ruler_button_text = if app.services.ruler_active { "📏 Ruler ✓" } else { "📏 Ruler" };
     if ui.button(ruler_button_text).clicked() {
-        app.ruler_active = !app.ruler_active;
-        if !app.ruler_active {
+        app.services.ruler_active = !app.services.ruler_active;
+        if !app.services.ruler_active {
             // Clear ruler when deactivated
-            app.ruler_start = None;
-            app.ruler_end = None;
+            app.services.ruler_start = None;
+            app.services.ruler_end = None;
         }
     }
     
     // Show ruler measurement if active and both points set
-    if app.ruler_active {
-        if let (Some(start), Some(end)) = (app.ruler_start, app.ruler_end) {
+    if app.services.ruler_active {
+        if let (Some(start), Some(end)) = (app.services.ruler_start, app.services.ruler_end) {
             let dx = end.x - start.x;
             let dy = end.y - start.y;
             let distance = (dx * dx + dy * dy).sqrt();
@@ -553,14 +546,14 @@ fn render_ruler_controls(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
                 ui.label(format!("📏 Distance: {:.3} mm", distance));
                 ui.label(format!("📐 ΔX: {:.3} mm, ΔY: {:.3} mm", dx.abs(), dy.abs()));
             }
-        } else if app.ruler_start.is_some() {
+        } else if app.services.ruler_start.is_some() {
             ui.label("Click second point to complete measurement");
         } else {
             ui.label("Click first point to start measurement (or press M to toggle)");
         }
     }
     // Show latched measurement if not in active measurement mode
-    else if let (Some(start), Some(end)) = (app.latched_measurement_start, app.latched_measurement_end) {
+    else if let (Some(start), Some(end)) = (app.services.latched_measurement_start, app.services.latched_measurement_end) {
         let dx = end.x - start.x;
         let dy = end.y - start.y;
         let distance = (dx * dx + dy * dy).sqrt();
@@ -599,10 +592,10 @@ fn setup_viewport(ui: &mut egui::Ui, app: &mut CopperForgeApp) -> (Rect, egui::R
     // Handle double-click to center view (but maintain custom origin)
     if response.double_clicked() {
         // Only reset the view, don't change the custom origin (design_offset)
-        app.needs_initial_view = true;
+        app.services.needs_initial_view = true;
         
-        let logger_state = app.logger_state.clone();
-        let log_colors = app.log_colors.clone();
+        let logger_state = app.services.logger_state.clone();
+        let log_colors = app.services.log_colors.clone();
         let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
         logger.log_info("Centered view (double-click)");
     }
@@ -620,34 +613,34 @@ fn handle_viewport_interactions(ui: &mut egui::Ui, app: &mut CopperForgeApp, vie
     handle_mouse_wheel_zoom(ui, app, viewport, response);
     
     // Update UI state if not dragging zoom window
-    if !app.zoom_window_dragging {
-        app.ui_state.update(ui, viewport, response, &mut app.view_state);
+    if !app.services.zoom_window_dragging {
+        app.services.ui_state.update(ui, viewport, response, &mut app.services.view_state);
         
         let viewport_center = viewport.center();
         
         // Calculate actual origin position based on custom origin if set
-        let design_offset = &app.display_manager.design_offset;
+        let design_offset = &app.services.display_manager.design_offset;
         if design_offset.x != 0.0 || design_offset.y != 0.0 {
             // Custom origin is set - convert to screen position
-            app.ui_state.origin_screen_pos = app.view_state.gerber_to_screen_coords(
+            app.services.ui_state.origin_screen_pos = app.services.view_state.gerber_to_screen_coords(
                 Vector2::from(design_offset.clone()).to_position().to_point2()
             );
         } else {
             // No custom origin - use viewport center
-            app.ui_state.origin_screen_pos = viewport_center;
+            app.services.ui_state.origin_screen_pos = viewport_center;
         }
         
-        app.ui_state.center_screen_pos = viewport_center;
+        app.services.ui_state.center_screen_pos = viewport_center;
         
         // Update cursor coordinates using raw transform (not affected by design_offset)
         if let Some(cursor_pos) = ui.input(|i| i.pointer.hover_pos()) {
             // Use the original gerber coordinate system for origin setting
-            let raw_gerber_pos = app.view_state.screen_to_gerber_coords(cursor_pos);
-            app.ui_state.cursor_gerber_coords = Some(raw_gerber_pos);
+            let raw_gerber_pos = app.services.view_state.screen_to_gerber_coords(cursor_pos);
+            app.services.ui_state.cursor_gerber_coords = Some(raw_gerber_pos);
         }
         
         // Show visual feedback when in origin setting mode
-        if app.setting_origin_mode {
+        if app.services.setting_origin_mode {
             ui.ctx().set_cursor_icon(egui::CursorIcon::Crosshair);
             
             // Draw preview text at cursor
@@ -664,7 +657,7 @@ fn handle_viewport_interactions(ui: &mut egui::Ui, app: &mut CopperForgeApp, vie
         }
         
         // Show visual feedback when in measurement mode
-        if app.ruler_active && !app.setting_origin_mode {
+        if app.services.ruler_active && !app.services.setting_origin_mode {
             ui.ctx().set_cursor_icon(egui::CursorIcon::Crosshair);
             
             // Draw preview text at cursor
@@ -672,7 +665,7 @@ fn handle_viewport_interactions(ui: &mut egui::Ui, app: &mut CopperForgeApp, vie
                 let painter = ui.painter();
                 
                 // Draw preview text
-                let text = if app.ruler_start.is_some() && app.ruler_end.is_none() {
+                let text = if app.services.ruler_start.is_some() && app.services.ruler_end.is_none() {
                     "Click second point to complete measurement"
                 } else {
                     "Click to start measurement"
@@ -688,38 +681,38 @@ fn handle_viewport_interactions(ui: &mut egui::Ui, app: &mut CopperForgeApp, vie
         }
         
         // Handle professional ruler tool with right-click drag
-        if app.ruler_active && !app.setting_origin_mode {
+        if app.services.ruler_active && !app.services.setting_origin_mode {
             handle_ruler_interaction(ui, app, response);
         }
         
         // Handle origin setting
-        if app.setting_origin_mode && response.clicked() {
-            if let Some(gerber_coords) = app.ui_state.cursor_gerber_coords {
+        if app.services.setting_origin_mode && response.clicked() {
+            if let Some(gerber_coords) = app.services.ui_state.cursor_gerber_coords {
                 // Enterprise feature: Apply snap to grid if enabled
-                let final_coords = if app.grid_settings.snap_enabled {
+                let final_coords = if app.services.grid_settings.snap_enabled {
                     let point = nalgebra::Point2::new(gerber_coords.x, gerber_coords.y);
-                    crate::display::snap_to_grid(point, &app.grid_settings)
+                    crate::display::snap_to_grid(point, &app.services.grid_settings)
                 } else {
                     nalgebra::Point2::new(gerber_coords.x, gerber_coords.y)
                 };
                 
-                app.display_manager.design_offset = crate::display::VectorOffset {
+                app.services.display_manager.design_offset = crate::display::VectorOffset {
                     x: final_coords.x,
                     y: final_coords.y,
                 };
-                app.setting_origin_mode = false;
-                app.origin_has_been_set = true;
+                app.services.setting_origin_mode = false;
+                app.services.origin_has_been_set = true;
                 
                 // Force view refresh to properly center coordinates at the new origin
-                app.needs_initial_view = true;
+                app.services.needs_initial_view = true;
                 
                 // Mark coordinates as dirty to force refresh
-                app.layer_store.mark_dirty();
+                app.services.layer_store.mark_dirty();
                 
-                let logger_state = app.logger_state.clone();
-                let log_colors = app.log_colors.clone();
+                let logger_state = app.services.logger_state.clone();
+                let log_colors = app.services.log_colors.clone();
                 let logger = ReactiveEventLogger::with_colors(&logger_state, &log_colors);
-                let snap_msg = if app.grid_settings.snap_enabled { " (snapped to grid)" } else { "" };
+                let snap_msg = if app.services.grid_settings.snap_enabled { " (snapped to grid)" } else { "" };
                 logger.log_info(&format!("Set origin to ({:.2}, {:.2}) mm{} - view recentered", final_coords.x, final_coords.y, snap_msg));
             }
         }
@@ -733,20 +726,20 @@ fn handle_zoom_window(ui: &mut egui::Ui, app: &mut CopperForgeApp, viewport: &Re
     if response.contains_pointer() {
         if ui.input(|i| i.pointer.button_pressed(right_button)) {
             if let Some(pos) = mouse_pos_screen {
-                app.zoom_window_start = Some(pos);
-                app.zoom_window_dragging = true;
+                app.services.zoom_window_start = Some(pos);
+                app.services.zoom_window_dragging = true;
             }
         }
     }
     
     // Complete zoom window
-    if app.zoom_window_dragging && ui.input(|i| i.pointer.button_released(right_button)) {
-        if let (Some(start), Some(end)) = (app.zoom_window_start, ui.input(|i| i.pointer.hover_pos())) {
+    if app.services.zoom_window_dragging && ui.input(|i| i.pointer.button_released(right_button)) {
+        if let (Some(start), Some(end)) = (app.services.zoom_window_start, ui.input(|i| i.pointer.hover_pos())) {
             let zoom_rect = Rect::from_two_pos(start, end);
             
             if zoom_rect.width() > 10.0 && zoom_rect.height() > 10.0 {
-                let gerber_start = app.view_state.screen_to_gerber_coords(zoom_rect.min);
-                let gerber_end = app.view_state.screen_to_gerber_coords(zoom_rect.max);
+                let gerber_start = app.services.view_state.screen_to_gerber_coords(zoom_rect.min);
+                let gerber_end = app.services.view_state.screen_to_gerber_coords(zoom_rect.max);
                 
                 let gerber_width = (gerber_end.x - gerber_start.x).abs() as f32;
                 let gerber_height = (gerber_end.y - gerber_start.y).abs() as f32;
@@ -758,10 +751,10 @@ fn handle_zoom_window(ui: &mut egui::Ui, app: &mut CopperForgeApp, viewport: &Re
                 let gerber_center_x = (gerber_start.x + gerber_end.x) / 2.0;
                 let gerber_center_y = (gerber_start.y + gerber_end.y) / 2.0;
                 
-                app.view_state.scale = new_scale;
+                app.services.view_state.scale = new_scale;
                 
                 let viewport_center = viewport.center();
-                app.view_state.translation = Vec2::new(
+                app.services.view_state.translation = Vec2::new(
                     viewport_center.x - (gerber_center_x * new_scale as f64) as f32,
                     viewport_center.y + (gerber_center_y * new_scale as f64) as f32
                 );
@@ -770,14 +763,14 @@ fn handle_zoom_window(ui: &mut egui::Ui, app: &mut CopperForgeApp, viewport: &Re
             }
         }
         
-        app.zoom_window_dragging = false;
-        app.zoom_window_start = None;
+        app.services.zoom_window_dragging = false;
+        app.services.zoom_window_start = None;
     }
     
     // Cancel zoom window on escape
-    if app.zoom_window_dragging && ui.input(|i| i.key_pressed(egui::Key::Escape)) {
-        app.zoom_window_dragging = false;
-        app.zoom_window_start = None;
+    if app.services.zoom_window_dragging && ui.input(|i| i.key_pressed(egui::Key::Escape)) {
+        app.services.zoom_window_dragging = false;
+        app.services.zoom_window_start = None;
     }
 }
 
@@ -802,21 +795,21 @@ fn handle_mouse_wheel_zoom(ui: &mut egui::Ui, app: &mut CopperForgeApp, _viewpor
         };
         
         // Get current scale and calculate new scale
-        let old_scale = app.view_state.scale;
+        let old_scale = app.services.view_state.scale;
         let new_scale = (old_scale * zoom_factor).clamp(0.01, 100.0);
         
         // Calculate the gerber coordinates at the mouse position before scaling
-        let gerber_point = app.view_state.screen_to_gerber_coords(mouse_pos);
+        let gerber_point = app.services.view_state.screen_to_gerber_coords(mouse_pos);
         
         // Update the scale
-        app.view_state.scale = new_scale;
+        app.services.view_state.scale = new_scale;
         
         // Calculate the new screen position of the same gerber point
-        let new_screen_pos = app.view_state.gerber_to_screen_coords(gerber_point);
+        let new_screen_pos = app.services.view_state.gerber_to_screen_coords(gerber_point);
         
         // Adjust translation to keep the mouse cursor over the same gerber point
         let translation_adjustment = mouse_pos - new_screen_pos;
-        app.view_state.translation += translation_adjustment;
+        app.services.view_state.translation += translation_adjustment;
         
         // Sync with ECS zoom resource
         app.sync_zoom_to_ecs();
@@ -827,22 +820,22 @@ fn render_gerber_content(ui: &mut egui::Ui, app: &mut CopperForgeApp, viewport: 
     let painter = ui.painter_at(*viewport);
     painter.rect_filled(*viewport, 0.0, ui.visuals().extreme_bg_color);
     
-    if app.needs_initial_view {
+    if app.services.needs_initial_view {
         app.reset_view(*viewport);
     }
     
     let painter = ui.painter().with_clip_rect(*viewport);
     
     // Draw grid
-    crate::display::draw_grid(&painter, viewport, &app.view_state, &app.grid_settings);
+    crate::display::draw_grid(&painter, viewport, &app.services.view_state, &app.services.grid_settings);
     
     // Draw quadrant axes
-    if app.display_manager.quadrant_view_enabled {
-        draw_quadrant_axes(&painter, viewport, &app.view_state, app.ui_state.origin_screen_pos);
+    if app.services.display_manager.quadrant_view_enabled {
+        draw_quadrant_axes(&painter, viewport, &app.services.view_state, app.services.ui_state.origin_screen_pos);
     }
     
     // Draw crosshairs - always at the active origin
-    draw_crosshair(&painter, app.ui_state.origin_screen_pos, Color32::BLUE);
+    draw_crosshair(&painter, app.services.ui_state.origin_screen_pos, Color32::BLUE);
     
     // Render layers using ECS system (gerber-viewer 0.2.0 compatible)
     app.render_layers_ecs(&painter);
@@ -856,22 +849,22 @@ fn render_gerber_content(ui: &mut egui::Ui, app: &mut CopperForgeApp, viewport: 
 
 
 fn render_overlays(app: &mut CopperForgeApp, painter: &Painter, viewport: &Rect) {
-    let screen_radius = MARKER_RADIUS * app.view_state.scale;
+    let screen_radius = MARKER_RADIUS * app.services.view_state.scale;
     
     // Origin marker - show only the active origin point
-    let design_offset = &app.display_manager.design_offset;
+    let design_offset = &app.services.display_manager.design_offset;
     let has_custom_origin = design_offset.x != 0.0 || design_offset.y != 0.0;
     
     if has_custom_origin {
         // Show custom origin (yellow marker) - this is the only visible origin
-        let design_offset_screen_position = app.view_state.gerber_to_screen_coords(Vector2::from(design_offset.clone()).to_position().to_point2());
+        let design_offset_screen_position = app.services.view_state.gerber_to_screen_coords(Vector2::from(design_offset.clone()).to_position().to_point2());
         draw_marker(painter, design_offset_screen_position, Color32::ORANGE, Color32::YELLOW, screen_radius);
     } else {
         // Show center origin (purple marker) when no custom origin is set
-        let purple_dot_pos = if app.display_manager.quadrant_view_enabled {
-            app.ui_state.center_screen_pos
+        let purple_dot_pos = if app.services.display_manager.quadrant_view_enabled {
+            app.services.ui_state.center_screen_pos
         } else {
-            app.ui_state.origin_screen_pos
+            app.services.ui_state.origin_screen_pos
         };
         draw_marker(painter, purple_dot_pos, Color32::PURPLE, Color32::MAGENTA, screen_radius);
     }
@@ -896,18 +889,18 @@ fn render_overlays(app: &mut CopperForgeApp, painter: &Painter, viewport: &Rect)
 }
 
 fn render_corner_overlays(app: &mut CopperForgeApp, painter: &Painter) {
-    if !app.drc_manager.corner_overlay_shapes.is_empty() {
+    if !app.services.drc_manager.corner_overlay_shapes.is_empty() {
         let overlay_color = Color32::from_rgb(0, 255, 0);
         
-        for shape in &app.drc_manager.corner_overlay_shapes {
+        for shape in &app.services.drc_manager.corner_overlay_shapes {
             let mut transformed_vertices = Vec::new();
             
             for point in &shape.points {
                 let mut vertex_pos = *point;
                 
                 // Apply rotation
-                if app.rotation_degrees != 0.0 {
-                    let rotation_radians = app.rotation_degrees.to_radians();
+                if app.services.rotation_degrees != 0.0 {
+                    let rotation_radians = app.services.rotation_degrees.to_radians();
                     let (sin_theta, cos_theta) = (rotation_radians.sin(), rotation_radians.cos());
                     
                     let rotated_x = vertex_pos.x * cos_theta as f64 - vertex_pos.y * sin_theta as f64;
@@ -916,18 +909,18 @@ fn render_corner_overlays(app: &mut CopperForgeApp, painter: &Painter) {
                 }
                 
                 // Apply mirroring
-                if app.display_manager.mirroring.x {
+                if app.services.display_manager.mirroring.x {
                     vertex_pos = vertex_pos.invert_x();
                 }
-                if app.display_manager.mirroring.y {
+                if app.services.display_manager.mirroring.y {
                     vertex_pos = vertex_pos.invert_y();
                 }
                 
                 // Apply offsets
-                let origin = Vector2::from(app.display_manager.center_offset.clone()) - Vector2::from(app.display_manager.design_offset.clone());
+                let origin = Vector2::from(app.services.display_manager.center_offset.clone()) - Vector2::from(app.services.display_manager.design_offset.clone());
                 vertex_pos = vertex_pos + origin.to_position();
                 
-                let vertex_screen = app.view_state.gerber_to_screen_coords(vertex_pos.to_point2());
+                let vertex_screen = app.services.view_state.gerber_to_screen_coords(vertex_pos.to_point2());
                 transformed_vertices.push(vertex_screen);
             }
             
@@ -943,13 +936,13 @@ fn render_corner_overlays(app: &mut CopperForgeApp, painter: &Painter) {
 }
 
 fn render_drc_violations(app: &mut CopperForgeApp, painter: &Painter) {
-    for violation in &app.drc_manager.violations {
+    for violation in &app.services.drc_manager.violations {
         let violation_pos = Position::new(violation.x as f64, violation.y as f64);
         let mut transformed_pos = violation_pos;
         
         // Apply rotation
-        if app.rotation_degrees != 0.0 {
-            let rotation_radians = app.rotation_degrees.to_radians();
+        if app.services.rotation_degrees != 0.0 {
+            let rotation_radians = app.services.rotation_degrees.to_radians();
             let (sin_theta, cos_theta) = (rotation_radians.sin(), rotation_radians.cos());
             let rotated_x = transformed_pos.x * cos_theta as f64 - transformed_pos.y * sin_theta as f64;
             let rotated_y = transformed_pos.x * sin_theta as f64 + transformed_pos.y * cos_theta as f64;
@@ -957,21 +950,21 @@ fn render_drc_violations(app: &mut CopperForgeApp, painter: &Painter) {
         }
         
         // Apply mirroring
-        if app.display_manager.mirroring.x {
+        if app.services.display_manager.mirroring.x {
             transformed_pos = transformed_pos.invert_x();
         }
-        if app.display_manager.mirroring.y {
+        if app.services.display_manager.mirroring.y {
             transformed_pos = transformed_pos.invert_y();
         }
         
         // Apply offsets
-        let origin = Vector2::from(app.display_manager.center_offset.clone()) - Vector2::from(app.display_manager.design_offset.clone());
+        let origin = Vector2::from(app.services.display_manager.center_offset.clone()) - Vector2::from(app.services.display_manager.design_offset.clone());
         transformed_pos = transformed_pos + origin.to_position();
         
-        let screen_pos = app.view_state.gerber_to_screen_coords(transformed_pos.to_point2());
+        let screen_pos = app.services.view_state.gerber_to_screen_coords(transformed_pos.to_point2());
         
         let base_size = 3.0;
-        let marker_size = base_size * app.view_state.scale.max(0.5);
+        let marker_size = base_size * app.services.view_state.scale.max(0.5);
         let color = Color32::RED;
         
         draw_violation_marker(painter, screen_pos, marker_size, color);
@@ -979,7 +972,7 @@ fn render_drc_violations(app: &mut CopperForgeApp, painter: &Painter) {
 }
 
 fn render_board_dimensions(app: &mut CopperForgeApp, painter: &Painter, viewport: &Rect) {
-    if let Some(layer) = app.layer_store.find(crate::layer_store::LayerType::MechanicalOutline) {
+    if let Some(layer) = app.services.layer_store.find(crate::layer_store::LayerType::MechanicalOutline) {
         let bbox = layer.gerber.bounding_box();
         let width_mm = bbox.width();
         let height_mm = bbox.height();
@@ -1007,8 +1000,8 @@ fn render_board_dimensions(app: &mut CopperForgeApp, painter: &Painter, viewport
 }
 
 fn render_zoom_window(app: &mut CopperForgeApp, painter: &Painter) {
-    if app.zoom_window_dragging {
-        if let (Some(start), Some(current)) = (app.zoom_window_start, painter.ctx().input(|i| i.pointer.hover_pos())) {
+    if app.services.zoom_window_dragging {
+        if let (Some(start), Some(current)) = (app.services.zoom_window_start, painter.ctx().input(|i| i.pointer.hover_pos())) {
             let zoom_rect = Rect::from_two_pos(start, current);
             
             // Draw semi-transparent fill
@@ -1041,19 +1034,19 @@ fn render_zoom_window(app: &mut CopperForgeApp, painter: &Painter) {
 
 fn render_ruler(app: &mut CopperForgeApp, painter: &Painter) {
     // Render active ruler if active
-    if app.ruler_active {
-        render_ruler_measurement(app, painter, app.ruler_start, app.ruler_end, true);
+    if app.services.ruler_active {
+        render_ruler_measurement(app, painter, app.services.ruler_start, app.services.ruler_end, true);
     }
     // Render latched ruler if not active but latched measurement exists
-    else if app.latched_measurement_start.is_some() && app.latched_measurement_end.is_some() {
-        render_ruler_measurement(app, painter, app.latched_measurement_start, app.latched_measurement_end, false);
+    else if app.services.latched_measurement_start.is_some() && app.services.latched_measurement_end.is_some() {
+        render_ruler_measurement(app, painter, app.services.latched_measurement_start, app.services.latched_measurement_end, false);
     }
 }
 
 fn render_ruler_measurement(app: &mut CopperForgeApp, painter: &Painter, start_opt: Option<nalgebra::Point2<f64>>, end_opt: Option<nalgebra::Point2<f64>>, is_active: bool) {
     // Draw ruler points and line
     if let Some(start) = start_opt {
-        let start_screen = app.view_state.gerber_to_screen_coords(start);
+        let start_screen = app.services.view_state.gerber_to_screen_coords(start);
         
         // Choose colors based on active/latched state
         let (point_color, line_color, text_color) = if is_active {
@@ -1067,7 +1060,7 @@ fn render_ruler_measurement(app: &mut CopperForgeApp, painter: &Painter, start_o
         painter.circle_stroke(start_screen, 6.0, Stroke::new(2.0, line_color));
         
         if let Some(end) = end_opt {
-            let end_screen = app.view_state.gerber_to_screen_coords(end);
+            let end_screen = app.services.view_state.gerber_to_screen_coords(end);
             
             // Draw end point
             painter.circle_filled(end_screen, 4.0, point_color);
@@ -1138,7 +1131,7 @@ fn render_ruler_measurement(app: &mut CopperForgeApp, painter: &Painter, start_o
 }
 
 fn handle_ruler_interaction(ui: &mut egui::Ui, app: &mut CopperForgeApp, response: &egui::Response) {
-    if !app.ruler_active {
+    if !app.services.ruler_active {
         return;
     }
     
@@ -1147,55 +1140,55 @@ fn handle_ruler_interaction(ui: &mut egui::Ui, app: &mut CopperForgeApp, respons
     // In ruler mode, left-click to set measurement points
     if response.clicked() {
         if let Some(mouse_screen_pos) = mouse_pos {
-            let gerber_coords = app.view_state.screen_to_gerber_coords(mouse_screen_pos);
+            let gerber_coords = app.services.view_state.screen_to_gerber_coords(mouse_screen_pos);
             
             // Apply snap to grid if enabled
-            let final_coords = if app.grid_settings.snap_enabled {
+            let final_coords = if app.services.grid_settings.snap_enabled {
                 let point = nalgebra::Point2::new(gerber_coords.x, gerber_coords.y);
-                crate::display::snap_to_grid(point, &app.grid_settings)
+                crate::display::snap_to_grid(point, &app.services.grid_settings)
             } else {
                 nalgebra::Point2::new(gerber_coords.x, gerber_coords.y)
             };
             
-            if app.ruler_start.is_none() {
+            if app.services.ruler_start.is_none() {
                 // First click - set start point
-                app.ruler_start = Some(final_coords);
-                app.ruler_end = None;
-                app.ruler_dragging = true; // Enable live preview
-            } else if app.ruler_end.is_none() {
+                app.services.ruler_start = Some(final_coords);
+                app.services.ruler_end = None;
+                app.services.ruler_dragging = true; // Enable live preview
+            } else if app.services.ruler_end.is_none() {
                 // Second click - set end point and complete measurement
-                app.ruler_end = Some(final_coords);
-                app.ruler_dragging = false;
+                app.services.ruler_end = Some(final_coords);
+                app.services.ruler_dragging = false;
             } else {
                 // Third click - start new measurement
-                app.ruler_start = Some(final_coords);
-                app.ruler_end = None;
-                app.ruler_dragging = true;
+                app.services.ruler_start = Some(final_coords);
+                app.services.ruler_end = None;
+                app.services.ruler_dragging = true;
             }
         }
     }
     
     // Show live preview when dragging (after first click, before second click)
-    if app.ruler_dragging && app.ruler_start.is_some() && mouse_pos.is_some() {
+    if app.services.ruler_dragging && app.services.ruler_start.is_some() && mouse_pos.is_some() {
         let mouse_screen_pos = mouse_pos.unwrap();
-        let gerber_coords = app.view_state.screen_to_gerber_coords(mouse_screen_pos);
+        let gerber_coords = app.services.view_state.screen_to_gerber_coords(mouse_screen_pos);
         
         // Apply snap to grid if enabled
-        let final_coords = if app.grid_settings.snap_enabled {
+        let final_coords = if app.services.grid_settings.snap_enabled {
             let point = nalgebra::Point2::new(gerber_coords.x, gerber_coords.y);
-            crate::display::snap_to_grid(point, &app.grid_settings)
+            crate::display::snap_to_grid(point, &app.services.grid_settings)
         } else {
             nalgebra::Point2::new(gerber_coords.x, gerber_coords.y)
         };
         
         // Update live preview end point
-        app.ruler_end = Some(final_coords);
+        app.services.ruler_end = Some(final_coords);
     }
 }
 
 fn render_cursor_info(ui: &mut egui::Ui, app: &mut CopperForgeApp, painter: &Painter, viewport: &Rect) {
     // Hide cursor coordinates when ruler mode is active
-    if app.ruler_active {
+    if app.services.ruler_active {
         return;
     }
     
@@ -1203,13 +1196,13 @@ fn render_cursor_info(ui: &mut egui::Ui, app: &mut CopperForgeApp, painter: &Pai
     
     if let Some(mouse_screen_pos) = mouse_pos_screen {
         if viewport.contains(mouse_screen_pos) {
-            let gerber_pos = app.view_state.screen_to_gerber_coords(mouse_screen_pos);
+            let gerber_pos = app.services.view_state.screen_to_gerber_coords(mouse_screen_pos);
             
             // Apply the design_offset as a simple coordinate offset for display
             // The design_offset is where we want (0,0) to be, so we subtract it from current position
             let adjusted_pos = Position::new(
-                gerber_pos.x - app.display_manager.design_offset.x,
-                gerber_pos.y - app.display_manager.design_offset.y
+                gerber_pos.x - app.services.display_manager.design_offset.x,
+                gerber_pos.y - app.services.display_manager.design_offset.y
             );
             
             let units_resource = Tab::get_units(app);
@@ -1290,31 +1283,31 @@ fn render_cursor_info(ui: &mut egui::Ui, app: &mut CopperForgeApp, painter: &Pai
 
 fn render_measurement_crosshair(app: &mut CopperForgeApp, painter: &Painter) {
     // Skip if in origin setting mode
-    if app.setting_origin_mode {
+    if app.services.setting_origin_mode {
         return;
     }
     
     // Draw crosshairs for active measurement points
-    if app.ruler_active {
-        if let Some(start_point) = app.ruler_start {
-            let screen_pos = app.view_state.gerber_to_screen_coords(start_point);
+    if app.services.ruler_active {
+        if let Some(start_point) = app.services.ruler_start {
+            let screen_pos = app.services.view_state.gerber_to_screen_coords(start_point);
             draw_measurement_crosshair(painter, screen_pos, Color32::from_rgb(139, 0, 0)); // Dark red for active
         }
         
-        if let Some(end_point) = app.ruler_end {
-            let screen_pos = app.view_state.gerber_to_screen_coords(end_point);
+        if let Some(end_point) = app.services.ruler_end {
+            let screen_pos = app.services.view_state.gerber_to_screen_coords(end_point);
             draw_measurement_crosshair(painter, screen_pos, Color32::from_rgb(139, 0, 0)); // Dark red for active
         }
     }
     // Draw crosshairs for latched measurement points (grayed out)
     else {
-        if let Some(start_point) = app.latched_measurement_start {
-            let screen_pos = app.view_state.gerber_to_screen_coords(start_point);
+        if let Some(start_point) = app.services.latched_measurement_start {
+            let screen_pos = app.services.view_state.gerber_to_screen_coords(start_point);
             draw_measurement_crosshair(painter, screen_pos, Color32::from_rgb(100, 100, 100)); // Gray for latched
         }
         
-        if let Some(end_point) = app.latched_measurement_end {
-            let screen_pos = app.view_state.gerber_to_screen_coords(end_point);
+        if let Some(end_point) = app.services.latched_measurement_end {
+            let screen_pos = app.services.view_state.gerber_to_screen_coords(end_point);
             draw_measurement_crosshair(painter, screen_pos, Color32::from_rgb(100, 100, 100)); // Gray for latched
         }
     }
@@ -1373,8 +1366,8 @@ impl<'a> egui_dock::TabViewer for TabViewer<'a> {
 fn render_zoom_display(ui: &mut egui::Ui, app: &mut CopperForgeApp) {
     // Get zoom info from ECS, fallback to legacy ViewState
     let (zoom_percentage, scale_factor) = (
-        app.layer_store.zoom.zoom_percentage(),
-        app.layer_store.zoom.scale,
+        app.services.layer_store.zoom.zoom_percentage(),
+        app.services.layer_store.zoom.scale,
     );
     
     // Format zoom display with appropriate precision


### PR DESCRIPTION
  Four commits on this branch; collectively a structural overhaul toward a                                                                                                         
  manufacturing-backend focus plus meaningful dep-graph reduction.                                                                                                                 
                                                                                                                                                                                   
  ## Architecture — AppLifecycle + SharedServices                                                                                                                                  
                                                                                                                                                                                   
  Replaces the implicit, lazy-first-frame initialization with an explicit                                                                                                          
  init sequence inside `CopperForgeApp::new()`:                                                                                                                                    
                                                                                                                                                                                   
  1. **LoadConfig** — reads `~/.config/copperforge/project_config.json`                                                                                                            
  2. **DiscoverKiCad** — one-time probe of `kicad-cli` (PATH → Flatpak → Snap).                                                                                                    
     Caches the discovery method; subsequent Generate-Gerbers clicks build a                                                                                                       
     `Command` without re-probing. On Flatpak hosts this turns a ~3s                                                                                                               
     button-click delay into a near-instant action.                                                                                                                                
  3. **InitializeDb** — opens the project DB                                                                                                                                       
  4. **Wire SharedServices** — populates the single cross-panel state container                                                                                                    
  5. **Register citizens** — panel lifecycle                                                                                                                                       
                                                                                                                                                                                   
  Failures at any stage panic with a stage-aware diagnostic (e.g. "delete                                                                                                          
  ~/.config/copperforge/projects.redb if corrupted").                                                                                                                              
                                                                                                                                                                                   
  `SharedServices` becomes the single source of truth for cross-panel state                                                                                                        
  (project_state as `Dynamic<ProjectState>`, layer_store, display_manager,                                                                                                         
  drc_manager, kicad_cli_method, project_db, etc.). `CopperForgeApp`                                                                                                               
  reduced to a thin outer shell (dispatcher, dock_state, file dialogs,                                                                                                             
  persisted citizen panels).                                                                                                                                                       
                                                                                                                                                                                   
  Stateful citizen panels (Bom / Terminal / Shell / Logger) own their own                                                                                                          
  state via the `citizen_panel!` macro's field support; instances persist                                                                                                          
  across frames on `CopperForgeApp`. Panel signatures flipped to                                                                                                                   
  `(&mut self, ui, &mut SharedServices)` where applicable.   


  New, explicit release flow:                                                                                                                                                      
  
  - **🚀 Release button** on the Gerber Viewer ribbon (gated on Ready state                                                                                                        
    + a current DB project record).
  - Modal fields: rev tag (auto-incremented default), include-date checkbox                                                                                                        
    (e.g. `_18Apr2026`), board description (prefilled from `.kicad_pro`),                                                                                                          
    changes textarea, include-RELEASE_NOTES.md-in-zip toggle.                                                                                                                      
  - `release/mod.rs::create_release()` creates                                                                                                                                     
    `<project>/outputs/<rev_tag>/` containing a zip of gerbers + drills                                                                                                            
    (`kicad-cli pcb export drill`) and a Markdown `RELEASE_NOTES.md`                                                                                                               
    (project + rev + timestamp + KiCad version + host OS + git commit                                                                                                              
    + description + changes).                                                                                                                                                      
  - `ProjectData.releases: Vec<Release>` persisted in DB;                                                                                                                          
    `#[serde(default)]` keeps old records readable.                                                                                                                                
  - **Regenerate flow** — right-click a `📦 rev_NN` node in the Projects                                                                                                           
    tree → Regenerate. Modal opens pre-filled, `overwrite_existing` flag                                                                                                           
    set, collision check skipped, existing release entry replaced in place.                                                                                                        
                                                                                                                                                                                   
  ## UX — Projects tab rework + modal                                                                                                                                              
                                                                                                                                                                                   
  - Right-pane "Project Details" column deleted. Projects tab is now a                                                                                                             
    single full-width tree.
  - Tree shape: project → schematic (+ sub-sheets) + pcb + `📁 outputs/`                                                                                                           
    with `📦 rev_NN` leaves.                                                                                                                                                       
  - Project nodes are `activatable(true)` — **double-click loads** the                                                                                                             
    project (PCB path + BOM restore).                                                                                                                                              
  - Right-click menu: Open / ✎ Update Project… / 🗑 Delete / ➕ New Child,
    plus 📂 Open release folder / 🔄 Regenerate Release on rev nodes.                                                                                                              
  - New **Project Details modal** (`app.rs`) — read-only PCB path, Author,                                                                                                         
    Company, Created, Last Modified; editable Name / Tags / Description;                                                                                                           
    collapsible Releases list; Save + Cancel.                                                                                                                                      
  - `ProjectManagerState.project_releases` cache bumped on create /                                                                                                                
    regenerate so the tree reflects new revs immediately without a DB                                                                                                              
    round-trip. 

  ## Top-ribbon rearrangement                                                                                                                                                      
                  
  - Prominent **current-project indicator** on the far left (green when a                                                                                                          
    project is loaded, dim when none) so a cold start with a remembered
    PCB is obvious.                                                                                                                                                                
  - Hotkeys menu moved next to the clock on the right.
                                                                                                                                                                                   
  ## Simplification pass
                                                                                                                                                                                   
  - Project tab reduced to **Import-only**. "Create New KiCad Project" UI                                                                                                          
    gone from the GUI; kept as a Shell command `new-project <name>` that
    scaffolds `~/projects/<name>/` with `.kicad_pro` / `.kicad_sch` /                                                                                                              
    `.kicad_pcb` stubs using config defaults, then registers it in the DB.                                                                                                         
  - Settings tab: KiCad Library Configuration block removed. Defaults now                                                                                                          
    sourced from `~/.config/copperforge/project_config.json` directly.                                                                                                             
  - `ProjectManagerState` trimmed: dropped `create_new_kicad_project`,                                                                                                             
    `new_kicad_project_location/author/company`, `include_kiverse`,                                                                                                                
    `include_atlantix_resistors`, `kiverse_path`, `location_dialog`.                                                                                                               
                                                                                                                                                                                   
  ## Shell / Terminal / Logger panels (ported from saturn-grid-sim)                                                                                                                
                                                                                                                                                                                   
  - **Shell** — CopperForge-aware commands: `help`, `ver` (full dependency                                                                                                         
    banner), `info` (OS/CPU/mem/net), `status`, `env` (discovered KiCad +
    KICAD\_\* env vars), `sh <cmd>`, `!<cmd>`, `new-project <name>`.                                                                                                               
  - **Terminal** — plain bash passthrough.                                                                                                                                         
  - **Logger** — saturn-style numbered rows + colored level prefixes,                                                                                                              
    reads from the existing `ReactiveEventLogger` state.                                                                                                                           
  - Retired `TabKind::EventLog` + `panels/event_log.rs`.  


  ## Dep cleanup (~120 crates shaved)                                                                                                                                              
                                                                                                                                                                                   
  - **sled → redb** (2.x). Preserves API shape: `Clone` derived on                                                                                                                 
    `ProjectDatabase` via `Arc<redb::Database>`. Filename changed from
    `projects.db` (sled dir) to `projects.redb` (file).                                                                                                                            
  - **image**: bumped 0.24 → 0.25 (matches `egui_extras` internal, dedupes
    two image versions); `default-features = false, features = ["png"]`.                                                                                                           
    Drops JPEG/GIF/TIFF/BMP/ICO/WebP decoders.                                                                                                                                     
  - **eframe** to `default-features = false` with glow + default_fonts +                                                                                                           
    wayland + x11 only. Drops `accesskit` feature — removes the                                                                                                                    
    accesskit_\* + atspi + zbus + zvariant screen-reader tail entirely.                                                                                                            
    No visible change; egui's Painter is backend-agnostic and we never                                                                                                             
    used accessibility.                                                                                                                                                            
  - **local-ip-address** dropped. Replaced with a small `hostname -I`                                                                                                              
    shell-out on Linux.                                                                                                                                                            
   
  ## Bug fixes rolled in                                                                                                                                                           
                                                                                                                                                                                   
  - Fixed: `ProjectDatabase::list_projects()` was clobbering
    `last_modified` with the PCB file mtime. Removed the overwrite.                                                                                                                                         
  - Fixed: project-description edits silently discarded. The edit buffer
    was stored under egui memory key `description_buffer_{id}` but read                                                                                                            
    at save time under `description_{id}` — mismatched keys.                                                                                                                       
  - Fixed: "Database not initialized" after the `services.project_db` +                                                                                                            
    `ProjectManagerState.database` double-open tripped sled's exclusive                                                                                                            
    directory lock. `initialize_database()` now clones the shared handle                                                                                                           
    instead of opening a second one. (Still relevant with redb — Arc                                                                                                               
    wrapping solves the same problem cleanly.)                                                                                                                                     
  - Fixed: picking the same `.kicad_pro` after a successful import was                                                                                                             
    a no-op because `last_picked_pro_path` wasn't cleared by                                                                                                                       
    `reset_create_dialog()`, producing "Project name cannot be empty."                                                                                                             
  - Fixed: Import tab showed the converted `.kicad_pcb` filename instead                                                                                                           
    of the `.kicad_pro` the user actually picked.                                                                                                                                  
  - Fixed: `.kicad_pro` file dialog didn't default to its filter; Browse                                                                                                           
    now opens with the KiCad Project filter active.                                                                                                                                
  - Added: dedup guard on import — refuses a second import of the same                                                                                                             
    `.kicad_pcb` path with a pointer to the existing record. 